### PR TITLE
Provide executable in `extract_build_ids` test

### DIFF
--- a/tests/integration/test_core_analyzer.py
+++ b/tests/integration/test_core_analyzer.py
@@ -540,7 +540,11 @@ def test_get_build_ids_from_core(tmpdir: Path) -> None:
     with generate_core_file(
         python_executable, TEST_SINGLE_THREAD_FILE, tmpdir
     ) as core_file:
-        core_map_analyzer = CoreFileAnalyzer(str(core_file))
+        # NOTE: `extract_build_ids` can fail if no executable is provided, but
+        # pystack always provides an executable when calling extract_build_ids,
+        # found using `extract_executable` if the user didn't provide it.
+        executable = CoreFileAnalyzer(str(core_file)).extract_executable()
+        core_map_analyzer = CoreFileAnalyzer(str(core_file), executable=executable)
         build_ids = set(core_map_analyzer.extract_build_ids())
 
     # THEN


### PR DESCRIPTION
Core files can elide read-only segments. If they do, the core file will be missing the `PHDR` segment, which is needed to locate `PT_DYNAMIC` and find the `r_debug` information.

`libdw` can handle this, by finding the `PHDR` segment in the executable image itself instead of in the core file, but it only does this fallback when the caller explicitly provides the executable to use (it doesn't use the executable recorded in the core file).

However, pystack's main always passes an executable explicitly before calling `CoreFileAnalyzer.extract_build_ids`. If the user doesn't provide the executable, it does an initial pass just to find the executable, and then a second pass with the executable provided.

Mirror that structure in the test for `extract_build_ids`, ensuring that an executable is provided before calling it, based on the executable path recorded in the core file.