### PR TITLE
ci: Install python-devel-2.7.5 on manylinux2014

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ manylinux-i686-image = "manylinux2014"
 
 [tool.cibuildwheel.linux]
 before-all = [
+  "yum install -y python-devel-2.7.5",
   "cd /",
   "curl  https://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xvf elfutils.tar.bz2",


### PR DESCRIPTION
We have some tests that exercise extracting stacks from Python 2.7 that we're not ready to drop yet. The manylinux2014 image contains a 2.7 executable that we can leverage to run these tests, but we need to install the headers explicitly.
