### PR TITLE
ci: Replace system libdw/libelf with our build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ before-all = [
   "curl  https://sourceware.org/elfutils/ftp/0.178/elfutils-0.178.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xvf elfutils.tar.bz2",
   "cd elfutils-0.178",
-  "CFLAGS='-w' ./configure --disable-libdebuginfod --disable-debuginfod",
+  "CFLAGS='-w' ./configure --disable-libdebuginfod --disable-debuginfod --prefix=/usr --libdir=/usr/lib64",
   "make install"
 ]


### PR DESCRIPTION
We were installing this into `/usr/local`, but our extension module build wasn't picking it up from there. Install it into `/usr/include` and `/usr/lib64` instead, so that it's on GCC's default search paths.
