### PR TITLE
Ignore non-readable guard pages before the heap

### DIFF
--- a/src/pystack/maps.py
+++ b/src/pystack/maps.py
@@ -296,7 +296,7 @@ def parse_maps_file_for_binary(
 
     heap_maps = maps_by_library.get("[heap]")
     if heap_maps is not None:
-        heap, *_ = heap_maps
+        *_, heap = heap_maps
         LOGGER.info("Heap map found: %r", heap)
 
     bss = _get_bss(elf_maps, load_point)


### PR DESCRIPTION
The heap managed by `sbrk` must be contiguous, but can be made up of multiple mappings. In theory any page of the heap could be given different permissions using an `mprotect` call, but only the `malloc` implementation itself could reasonably do so. In practice, the only case of multiple heap mappings that we've seen is musl libc putting a non-readable, non-writable guard page at the start of the heap.

Rather than attempt to handle this in a more general way, make an assumption that works for all of the cases we've actually observed in practice: assume that, if the heap is made up of multiple separate mappings, we can ignore all but the last one (which is the one that can still grow with future calls to `sbrk`).