### PR TITLE
Avoid confusing anonymous maps for heap maps

### DIFF
--- a/src/pystack/maps.py
+++ b/src/pystack/maps.py
@@ -296,7 +296,7 @@ def parse_maps_file_for_binary(
 
     heap_maps = maps_by_library.get("[heap]")
     if heap_maps is not None:
-        *_, heap = heap_maps
+        *_, heap = [m for m in heap_maps if getattr(m.path, "name", None) == "[heap]"]
         LOGGER.info("Heap map found: %r", heap)
 
     bss = _get_bss(elf_maps, load_point)


### PR DESCRIPTION
The fix for anonymous guard pages was incorrect because `heap_maps` includes not only maps whose file is listed as `[heap]` but also anonymous maps following the true heap mapping.

When we're trying to discover which VMAs correspond to the heap, only consider the subset of `heap_maps` where the path is actually `[heap]`.
