### PR TITLE
tests: Drop heap method from smoke tests for 3.11+

### DIFF
--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -16,8 +16,11 @@ TEST_SINGLE_THREAD_FILE = Path(__file__).parent / "single_thread_program.py"
 if sys.version_info < (3, 10):
     STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.BSS, StackMethod.HEAP)
     CORE_STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.BSS)
-else:
+elif sys.version_info < (3, 11):
     STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA, StackMethod.HEAP)
+    CORE_STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA)
+else:
+    STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA)
     CORE_STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA)
 
 


### PR DESCRIPTION
In Python 3.11 and later, finding the `PyInterpreterState` by scanning the heap is unlikely to work for a single-threaded program. In older Python versions, we should always find a `PyThreadState` on the heap, which would hold a pointer to the `PyInterpreterState`. From 3.11 onwards, however, the main thread's `PyThreadState` is statically allocated rather than heap allocated, so this method isn't likely to work for single threaded programs (though it continues to work for multithreaded programs, which will have some heap-allocated `PyThreadState` instances).
