### PR TITLE
Hack around infinite loop while unwinding on musl

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -94,6 +94,37 @@ jobs:
           PYTHON_TEST_VERSION: ${{ matrix.python_version }}
         run: python3 -m pytest tests -k 'not 2.7' -n auto -vvv
 
+
+  test_in_alpine:
+      needs: [build_wheels, build_sdist]
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+
+      container:
+        image: alpine
+        options: --cap-add=SYS_PTRACE
+
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
+          with:
+            name: artifact
+            path: dist
+        - name: Set up dependencies
+          run: |
+              apk add --update alpine-sdk bash alpine-sdk python3 python3-dev gdb elfutils elfutils-dev musl-dbg python3-dbg
+        - name: Install Python dependencies
+          run: |
+            python3 -m venv venv
+            venv/bin/python3 -m pip install --upgrade pip
+            venv/bin/python3 -m pip install -r requirements-test.txt
+            venv/bin/python3 -m pip install .
+        - name: Run pytest
+          env:
+            PYTHON_TEST_VERSION: "3.9"
+          run: venv/bin/python3 -m pytest tests -k 'not 2.7' -n auto -vvv
+
   test_wheels_in_fedora:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest

--- a/src/pystack/_pystack/unwinder.h
+++ b/src/pystack/_pystack/unwinder.h
@@ -39,6 +39,19 @@ class Frame
     bool isActivation;
 };
 
+inline bool
+operator==(const Frame& lhs, const Frame& rhs)
+{
+    return lhs.pc == rhs.pc && lhs.isActivation == rhs.isActivation;
+}
+
+inline bool
+operator!=(const Frame& lhs, const Frame& rhs)
+{
+    return !(lhs == rhs);
+}
+
+
 class ModuleCuDieRanges
 {
   public:

--- a/tests/integration/test_core_analyzer.py
+++ b/tests/integration/test_core_analyzer.py
@@ -22,6 +22,7 @@ from tests.utils import all_pystack_combinations
 from tests.utils import generate_core_file
 from tests.utils import python_has_inlined_eval_frames
 from tests.utils import python_has_position_information
+from tests.utils import xfail_on_expected_exceptions
 
 CORE_FILE_PATHS = Path(__file__).parent / "corefiles"
 TEST_SINGLE_THREAD_FILE = Path(__file__).parent / "single_thread_program.py"
@@ -54,9 +55,12 @@ def test_single_thread_stack(
     with generate_core_file(
         python_executable, TEST_SINGLE_THREAD_FILE, tmpdir
     ) as core_file:
-        threads = list(
-            get_process_threads_for_core(core_file, python_executable, method=method)
-        )
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads_for_core(
+                    core_file, python_executable, method=method
+                )
+            )
 
     # THEN
 
@@ -164,9 +168,12 @@ def test_multiple_thread_stack_native(
     with generate_core_file(
         python_executable, TEST_MULTIPLE_THREADS_FILE, tmpdir
     ) as core_file:
-        threads = list(
-            get_process_threads_for_core(core_file, python_executable, method=method)
-        )
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads_for_core(
+                    core_file, python_executable, method=method
+                )
+            )
 
     # THEN
 

--- a/tests/integration/test_gather_stacks.py
+++ b/tests/integration/test_gather_stacks.py
@@ -20,6 +20,7 @@ from tests.utils import all_pystack_combinations
 from tests.utils import python_has_inlined_eval_frames
 from tests.utils import python_has_position_information
 from tests.utils import spawn_child_process
+from tests.utils import xfail_on_expected_exceptions
 
 TEST_SINGLE_THREAD_FILE = Path(__file__).parent / "single_thread_program.py"
 TEST_MULTIPLE_THREADS_FILE = Path(__file__).parent / "multiple_thread_program.py"
@@ -45,9 +46,12 @@ def test_single_thread_stack(python, blocking, method, tmpdir):
     with spawn_child_process(
         python_executable, TEST_SINGLE_THREAD_FILE, tmpdir
     ) as child_process:
-        threads = list(
-            get_process_threads(child_process.pid, stop_process=blocking, method=method)
-        )
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads(
+                    child_process.pid, stop_process=blocking, method=method
+                )
+            )
 
     # THEN
 
@@ -110,9 +114,12 @@ def test_multiple_thread_stack(python, blocking, method, tmpdir):
     with spawn_child_process(
         python_executable, TEST_MULTIPLE_THREADS_FILE, tmpdir
     ) as child_process:
-        threads = list(
-            get_process_threads(child_process.pid, stop_process=blocking, method=method)
-        )
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads(
+                    child_process.pid, stop_process=blocking, method=method
+                )
+            )
 
     # THEN
 
@@ -168,13 +175,14 @@ def test_single_thread_stack_native(python, method, blocking, tmpdir):
     with spawn_child_process(
         python_executable, TEST_SINGLE_THREAD_FILE, tmpdir
     ) as child_process:
-        threads = list(
-            get_process_threads(
-                child_process.pid,
-                native_mode=NativeReportingMode.PYTHON,
-                stop_process=blocking,
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads(
+                    child_process.pid,
+                    native_mode=NativeReportingMode.PYTHON,
+                    stop_process=blocking,
+                )
             )
-        )
 
     # THEN
 
@@ -224,13 +232,14 @@ def test_multiple_thread_stack_native(python, method, blocking, tmpdir):
     with spawn_child_process(
         python_executable, TEST_MULTIPLE_THREADS_FILE, tmpdir
     ) as child_process:
-        threads = list(
-            get_process_threads(
-                child_process.pid,
-                native_mode=NativeReportingMode.PYTHON,
-                stop_process=blocking,
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads(
+                    child_process.pid,
+                    native_mode=NativeReportingMode.PYTHON,
+                    stop_process=blocking,
+                )
             )
-        )
 
     # THEN
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -10,6 +10,7 @@ from pystack.engine import get_process_threads
 from pystack.engine import get_process_threads_for_core
 from tests.utils import generate_core_file
 from tests.utils import spawn_child_process
+from tests.utils import xfail_on_expected_exceptions
 
 TEST_SINGLE_THREAD_FILE = Path(__file__).parent / "single_thread_program.py"
 
@@ -37,9 +38,12 @@ def test_simple_execution(method, blocking, tmpdir):
     with spawn_child_process(
         sys.executable, TEST_SINGLE_THREAD_FILE, tmpdir
     ) as child_process:
-        threads = list(
-            get_process_threads(child_process.pid, method=method, stop_process=blocking)
-        )
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads(
+                    child_process.pid, method=method, stop_process=blocking
+                )
+            )
 
     # THEN
     assert threads is not None
@@ -57,11 +61,14 @@ def test_simple_execution_native(method, tmpdir):
     with spawn_child_process(
         sys.executable, TEST_SINGLE_THREAD_FILE, tmpdir
     ) as child_process:
-        threads = list(
-            get_process_threads(
-                child_process.pid, method=method, native_mode=NativeReportingMode.PYTHON
+        with xfail_on_expected_exceptions(method):
+            threads = list(
+                get_process_threads(
+                    child_process.pid,
+                    method=method,
+                    native_mode=NativeReportingMode.PYTHON,
+                )
             )
-        )
 
     # THEN
     assert threads is not None


### PR DESCRIPTION
The elfutils library fails to successfully unwind multithreaded applications using musl libc. It gets stuck at the thread entry point (presumably due to poor debugging information in musl itself) and continually unwinds to the same instruction pointer forever.

Work around this with an ugly hack: when our callback is passed the same instruction pointer 5 times in a row, and the instruction pointer before those 5 was different, check to see if the function we've unwound to is called __clone and lives in ld-musl.so, and if so, break out of the loop on our own.

This should have minimal performance overhead for typical programs, and will not affect correctness when unwinding programs using glibc. The biggest risk is that there are some other cases where elfutils would begin to loop while unwinding musl code. That is: this has next to no chance of false positives, but does run a risk of false negatives.

Closes: #3 