### PR TITLE
Stop assuming relative paths are relative to cwd

### DIFF
--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -422,9 +422,6 @@ cdef object _construct_frame_stack_from_thread_object(
         current_code = current_frame.Code().get()
 
         filename = current_code.Filename()
-        if not os.path.isabs(filename):
-            filename = os.path.realpath(os.path.join(f"/proc/{pid}/cwd", filename))
-
         location_info = LocationInfo(
                 current_code.Location().lineno,
                 current_code.Location().end_lineno,


### PR DESCRIPTION
This was always wrong for core files (the process is no longer running, so we can't find out what working directory it had via /proc), but this is also subtly wrong for running processes: the script may have changed the working directory after the file was opened, and the path that it's relative to might be the old working directory.  It seems slightly more correct to use `sys.path[0]` rather than the script's working directory as our base, but that's much more difficult than just assuming that the user is running `pystack` from the same directory as the script they're tracing and leaving paths relative. Moreover, a user can change entries in `sys.path` at runtime, so that trick wouldn't be bulletproof either.
