### PR TITLE
Harden `Py_TPFLAGS_*_SUBCLASS` checks

### DIFF
--- a/src/pystack/_pystack/cpython/object.h
+++ b/src/pystack/_pystack/cpython/object.h
@@ -221,7 +221,5 @@ constexpr long Pystack_TPFLAGS_UNICODE_SUBCLASS = 1uL << 28u;
 constexpr long Pystack_TPFLAGS_DICT_SUBCLASS = 1uL << 29u;
 constexpr long Pystack_TPFLAGS_BASE_EXC_SUBCLASS = 1uL << 30u;
 constexpr long Pystack_TPFLAGS_TYPE_SUBCLASS = 1uL << 31u;
-constexpr long Pystack_TPFLAGS_STRING_SUBCLASS =
-        (Pystack_TPFLAGS_BYTES_SUBCLASS | Pystack_TPFLAGS_UNICODE_SUBCLASS);
 
 }  // namespace pystack

--- a/src/pystack/_pystack/pytypes.cpp
+++ b/src/pystack/_pystack/pytypes.cpp
@@ -602,25 +602,41 @@ Object::toBool() const
 Object::ObjectType
 Object::objectType() const
 {
-    if (PYTHON_MAJOR_VERSION > 2 && hasFlags(Pystack_TPFLAGS_BYTES_SUBCLASS)) {
-        return ObjectType::BYTES;
-    } else if (hasFlags(Pystack_TPFLAGS_STRING_SUBCLASS)) {
+    // clang-format off
+    constexpr long subclass_mask =
+            (Pystack_TPFLAGS_INT_SUBCLASS
+             | Pystack_TPFLAGS_LONG_SUBCLASS
+             | Pystack_TPFLAGS_LIST_SUBCLASS
+             | Pystack_TPFLAGS_TUPLE_SUBCLASS
+             | Pystack_TPFLAGS_BYTES_SUBCLASS
+             | Pystack_TPFLAGS_UNICODE_SUBCLASS
+             | Pystack_TPFLAGS_DICT_SUBCLASS
+             | Pystack_TPFLAGS_BASE_EXC_SUBCLASS
+             | Pystack_TPFLAGS_TYPE_SUBCLASS);
+    // clang-format on
+
+    const long subclass_flags = d_flags & subclass_mask;
+
+
+    if (subclass_flags == Pystack_TPFLAGS_BYTES_SUBCLASS) {
+        return PYTHON_MAJOR_VERSION > 2 ? ObjectType::BYTES : ObjectType::STRING;
+    } else if (subclass_flags == Pystack_TPFLAGS_UNICODE_SUBCLASS) {
         return ObjectType::STRING;
-    } else if (hasFlags(Pystack_TPFLAGS_INT_SUBCLASS)) {
+    } else if (subclass_flags == Pystack_TPFLAGS_INT_SUBCLASS) {
         if (d_classname == "bool") {
             return ObjectType::INT_BOOL;
         }
         return ObjectType::INT;
-    } else if (hasFlags(Pystack_TPFLAGS_LONG_SUBCLASS)) {
+    } else if (subclass_flags == Pystack_TPFLAGS_LONG_SUBCLASS) {
         if (d_classname == "bool") {
             return ObjectType::LONG_BOOL;
         }
         return ObjectType::LONG;
-    } else if (hasFlags(Pystack_TPFLAGS_TUPLE_SUBCLASS)) {
+    } else if (subclass_flags == Pystack_TPFLAGS_TUPLE_SUBCLASS) {
         return ObjectType::TUPLE;
-    } else if (hasFlags(Pystack_TPFLAGS_LIST_SUBCLASS)) {
+    } else if (subclass_flags == Pystack_TPFLAGS_LIST_SUBCLASS) {
         return ObjectType::LIST;
-    } else if (hasFlags(Pystack_TPFLAGS_DICT_SUBCLASS)) {
+    } else if (subclass_flags == Pystack_TPFLAGS_DICT_SUBCLASS) {
         return ObjectType::DICT;
     } else if (d_classname == "float") {
         return ObjectType::FLOAT;


### PR DESCRIPTION
Any actual class should have at most one of these subclass type flags set. If we see multiple of them set, it's safest to not trust that any of them are correct, and instead fall back to our opaque "other" handling.
