### PR TITLE
Allow overriding library paths from core files

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+pyinstaller
 pytest
 pytest-cov
 pytest-xdist

--- a/src/pystack/_pystack/elf_common.h
+++ b/src/pystack/_pystack/elf_common.h
@@ -74,7 +74,7 @@ class CoreFileAnalyzer : public Analyzer
     std::vector<std::string> d_missing_modules{};
 
 private:
-    void removeModuleIf(std::function<bool(Dwfl_Module*)> predicate);
+    void removeModuleIf(std::function<bool(Dwfl_Module*)> predicate) const;
     void resolveLibraries();
 };
 

--- a/src/pystack/_pystack/elf_common.h
+++ b/src/pystack/_pystack/elf_common.h
@@ -72,6 +72,10 @@ class CoreFileAnalyzer : public Analyzer
     int d_pid;
     elf_unique_ptr d_elf;
     std::vector<std::string> d_missing_modules{};
+
+private:
+    void removeModuleIf(std::function<bool(Dwfl_Module*)> predicate);
+    void resolveLibraries();
 };
 
 class ProcessAnalyzer : public Analyzer

--- a/tests/integration/test_relocatable_cores.py
+++ b/tests/integration/test_relocatable_cores.py
@@ -107,7 +107,7 @@ def test_single_thread_stack_for_relocated_core(
         for frame in thread.native_frames
         if frame_type(frame, thread.python_version) == NativeFrame.FrameType.EVAL
     ]
-    assert len(eval_frames) >= 4
+    assert len(eval_frames) == sum(frame.is_entry for frame in frames)
     assert all("?" not in frame.symbol for frame in eval_frames)
     assert all(frame.linenumber != 0 for frame in eval_frames if "?" not in frame.path)
 


### PR DESCRIPTION
This enables analyzing a core file even if the libraries that were used by the application are not installed at the time PyStack is run (perhaps because the libraries on the machine have been updated). By providing PyStack with a set of directories to search for libraries in and placing the versions of the libraries that the application was using in those directories, users can analyze the core file without needing to modify the currently installed libraries on the machine.
