### PR TITLE
Drop hard dependency on elfutils 0.188

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Check your package manager on how to install these dependencies (e.g.,
 `apt-get install libdw-dev libelf-dev` in Debian-based systems). Note that you may need to tell the
 compiler where to find the header and library files of the dependencies for the build to
 succeed. Check your distribution's documentation to determine the location of the header and
-library files or for more detailed information.
+library files or for more detailed information. When building on Alpine Linux (or any other
+distribution that doesn't use glibc) you'll need elfutils 0.188 or newer. You may need to build this
+from source if your distribution's package manager doesn't have it.
 
 Once you have these binary dependencies installed, you can clone the repository and follow the
 typical build process for Python libraries:


### PR DESCRIPTION
This version of elfutils isn't available in most distributions yet, which makes a hard dependency on it (for `dwfl_frame_reg`) annoying. Since we only need such a new version for trying to avoid the infinite loop when gathering stacks for interpreters using musl libc, cheat and avoid performing the check when PyStack itself is built using glibc.

This isn't perfectly correct, but it should work for the overwhelming majority of cases, and lets us continue to be built with the versions of elfutils in most common distributions.

Update the README to call out that Alpine users will likely need to build elfutils from source in order to build PyStack from source, at least for now.