### PR TITLE
typo: Remove references to `memray`

### DIFF
--- a/.github/ISSUE_TEMPLATE/---feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/---feature-request.yaml
@@ -23,7 +23,7 @@ body:
     label: Describe the solution you'd like
     description: A clear and concise description of what you want to happen. Add any considered drawbacks.
     placeholder: |
-      I would love if Memray could [...]
+      I would love if PyStack could [...]
   validations:
     required: True
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Long question or idea
-    url: https://github.com/bloomberg/memray/discussions
+    url: https://github.com/bloomberg/pystack/discussions
     about: Ask long-form questions and discuss ideas.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,13 +5,14 @@ fix problems like typo corrections or such.
 
 .. towncrier release notes start
 
+
 pystack 1.0.1 (2023-04-11)
 ==========================
 
 No significant changes.
 
 
-memray 1.0.0 (2023-04-06)
--------------------------
+pystack 1.0.0 (2023-04-06)
+==========================
 
 -  Initial release.


### PR DESCRIPTION
This was likely included by mistake. Running `make release` (with `RELEASE=patch` or `RELEASE=minor` or `RELEASE=major`) will also generate a consistent `NEWS.rst` in the future.
