### PR TITLE
ci: Add sanity-check workflow: require DCO and news entry

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,30 @@
+name: Sanity check
+on: 
+  pull_request:
+    types:
+    - "opened"
+    - "reopened"
+    - "synchronize"
+    - "labeled"
+    - "unlabeled"
+
+jobs:
+  commits_check_job:
+    runs-on: ubuntu-latest
+    name: Commits Check
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+    - name: "Check for news entry"
+      uses: brettcannon/check-for-changed-files@v1
+      with:
+        file-pattern: "news/*.rst"
+        skip-label: "skip news"
+        failure-message: "Missing a news file in ${file-pattern}; please add one or apply the ${skip-label} label to the pull request"


### PR DESCRIPTION
#55 

**Describe your changes**
Copied [Memray's `sanity-check.yml` workflow](https://github.com/bloomberg/memray/blob/main/.github/workflows/sanity-check.yml) into pystack, as discussed offline.

Checks for:
- [News entry or `skip news` label.](https://github.com/brettcannon/check-for-changed-files)
- [DCO on commits.](https://github.com/tim-actions/dco)

**Testing performed**
Tested multiple pull requests on my fork:
- austinlg96/pystack#1
- austinlg96/pystack#2
- austinlg96/pystack#3
  - Checks failed (=success) until `skip news` label was added (=success)
- austinlg96/pystack#4


**Additional context**
Part of PyCon 2023 Sprints
