### PR TITLE
Add `file` package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
     gdb \
     valgrind \
     lcov \
+    file \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This eliminates errors while testing inside of docker due to the missing file package

*Issue number of the reported bug or feature request: #69 

**Describe your changes**
Added `file` package to `Dockerfile`

**Testing performed**
Reran `make check` inside of the Dockefile and tests are able to continue.

**Additional context**
None
