### PR TITLE
Remove `extras-requires`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install-sdist: dist  ## Install from source distribution
 
 .PHONY: test-install
 test-install:  ## Install with test dependencies
-	$(ENV) CYTHON_TEST_MACROS=1 $(PIP_INSTALL) -e .[test]
+	$(ENV) CYTHON_TEST_MACROS=1 $(PIP_INSTALL) -e . -r requirements-test.txt
 
 .PHONY: check
 check:  ## Run the test suite

--- a/setup.py
+++ b/setup.py
@@ -7,29 +7,6 @@ from setuptools import Extension
 from Cython.Build import cythonize
 
 install_requires = []
-docs_requires = [
-    "bump2version",
-    "recommonmark",
-    "sphinx",
-    "furo",
-    "sphinx-autobuild",
-    "sphinx-argparse",
-    "towncrier",
-]
-
-lint_requires = [
-    "black",
-    "flake8",
-    "isort",
-    "mypy",
-]
-
-test_requires = [
-    "Cython",
-    "pytest",
-    "pytest-xdist",
-    "pytest-cov",
-]
 
 
 TEST_BUILD = False
@@ -136,12 +113,6 @@ setup(
     ),
     install_requires=install_requires,
     include_package_data=True,
-    extras_require={
-        "test": test_requires,
-        "docs": docs_requires,
-        "lint": lint_requires,
-        "dev": test_requires + lint_requires + docs_requires,
-    },
     entry_points={
         "console_scripts": ["pystack=pystack.__main__:main"],
     },


### PR DESCRIPTION
Having these dependencies both in `requirements-*.txt` as well as in `setup.py` allows for inconsistencies, such as the missing `pyinstaller` dependency that really should be in the test dependencies. After discussing this, it seems like it's harder to read the `setup.py` file by Docker and CI in general than the `requirements-*.txt`.

**Describe your changes**
This PR removes all `extras_require` sections from `setup.py`, such that the development dependencies are not part of the package that gets published to PyPI.

**Testing performed**
Reinstalling and running all of the tests and coverage locally with that new setup.

**Additional context**
PyCon US 2023 ftw.
