### PR TITLE
Streamline linting process

### DIFF
--- a/.github/workflows/lint_and_docs.yml
+++ b/.github/workflows/lint_and_docs.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Lint sources
         run: |
           make lint
+          python3 -m pre_commit run --all-files --hook-stage pre-push
       - name: Build docs
         run: |
           make docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,12 @@ repos:
       - id: isort
         stages: [pre-commit]
 
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v0.6.7
+    hooks:
+      - id: sphinx-lint
+        stages: [pre-commit]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,68 @@
+default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: check-added-large-files
+        stages: [pre-commit]
       - id: check-json
+        stages: [pre-commit]
       - id: check-merge-conflict
+        stages: [pre-commit]
       - id: check-toml
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: trailing-whitespace
+        stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: rst-directive-colons
+        stages: [pre-commit]
       - id: rst-inline-touching-normal
+        stages: [pre-commit]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
+        stages: [pre-commit]
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
+        stages: [pre-commit]
         types: [file, python]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
+        stages: [pre-commit]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
+        args: [--no-editorconfig]
         exclude_types: [html]
+        stages: [pre-commit]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.2
+    hooks:
+      - id: clang-format
+        args: [--Werror, -i]
+        types_or: [c++, c, cuda]
+        stages: [pre-commit]
+
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.49"
+    hooks:
+      - id: check-manifest
+        stages: [pre-push]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include Makefile
 include src/pystack/py.typed
 include .pre-commit-config.yaml
 
-recursive-include src/pystack/_pystack/ *
+recursive-include src/pystack/_pystack *
 recursive-include src/pystack *.py
 recursive-include src/pystack *.pyx *.pxd
 recursive-include src/pystack *.pxd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,29 @@
+exclude .clang-format
+exclude .prettierignore
+exclude CONTRIBUTING.md
+exclude Dockerfile
 exclude src/pystack/*.cpp
 exclude src/pystack/*.h
+exclude requirements-*.txt
+exclude tox.ini
+exclude valgrind.supp
 
 include pyproject.toml
 include Makefile
+include NEWS.rst
+include README.md
 include src/pystack/py.typed
+include .bumpversion.cfg
 include .pre-commit-config.yaml
+include .prettierrc.yaml
 
 recursive-include src/pystack/_pystack *
 recursive-include src/pystack *.py
 recursive-include src/pystack *.pyx *.pxd
 recursive-include src/pystack *.pxd
 recursive-include src/pystack *.pyi
+
+recursive-exclude docs *
+recursive-exclude news *
+recursive-exclude tests *
+recursive-exclude .vscode *

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PYTHON ?= python
-CLANG_FORMAT ?= clang-format
 
 # Doc generation variables
 UPSTREAM_GIT_REMOTE ?= origin

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,6 +1,3 @@
-black
-flake8
-isort
 mypy
 bump2version
 towncrier

--- a/src/pystack/_pystack/elf_common.cpp
+++ b/src/pystack/_pystack/elf_common.cpp
@@ -215,7 +215,8 @@ CoreFileAnalyzer::resolveLibraries()
                     module.path.c_str(),
                     -1,
                     module.addr,
-                    false)) {
+                    false))
+        {
             LOG(ERROR) << "Failed to report module " << module.modname << ": "
                        << dwfl_errmsg(dwfl_errno());
             throw ElfAnalyzerError("Failed to report ELF modules for core file");

--- a/src/pystack/_pystack/pythread.cpp
+++ b/src/pystack/_pystack/pythread.cpp
@@ -290,7 +290,8 @@ PyThread::calculateGilStatus(const std::shared_ptr<const AbstractProcessManager>
             static const size_t MAX_RUNTIME_OFFSET = 2048;
             for (void** raddr = (void**)pyruntime;
                  (void*)raddr < (void*)(pyruntime + MAX_RUNTIME_OFFSET);
-                 raddr++) {
+                 raddr++)
+            {
                 manager->copyObjectFromProcess((remote_addr_t)raddr, &thread_addr);
                 if (thread_addr == d_addr && ++hits == 2) {
                     LOG(DEBUG) << "GIL status correctly determined: HELD";

--- a/tests/integration/empty_thread_extension/testext.cpp
+++ b/tests/integration/empty_thread_extension/testext.cpp
@@ -24,7 +24,7 @@ sleep10(PyObject*, PyObject*)
     Py_BEGIN_ALLOW_THREADS ret = pthread_join(thread, NULL);
     Py_END_ALLOW_THREADS
 
-    assert(0 == ret);
+            assert(0 == ret);
     Py_RETURN_NONE;
 }
 

--- a/tests/integration/empty_thread_extension_with_os_threads/testext.cpp
+++ b/tests/integration/empty_thread_extension_with_os_threads/testext.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 
 #pragma GCC push_options
-#pragma GCC optimize ("O0")
+#pragma GCC optimize("O0")
 
 void*
 os_thread(void*)
@@ -14,7 +14,8 @@ os_thread(void*)
     sleep(10000);
 }
 
-pthread_t start_os_thread()
+pthread_t
+start_os_thread()
 {
     pthread_t thread;
     int ret = pthread_create(&thread, NULL, &os_thread, NULL);
@@ -23,7 +24,8 @@ pthread_t start_os_thread()
     return ret;
 }
 
-void cancel_os_thread(pthread_t tid)
+void
+cancel_os_thread(pthread_t tid)
 {
     pthread_join(tid, NULL);
 }
@@ -49,7 +51,7 @@ sleep10(PyObject*, PyObject*)
     Py_BEGIN_ALLOW_THREADS ret = pthread_join(thread, NULL);
     Py_END_ALLOW_THREADS
 
-    assert(0 == ret);
+            assert(0 == ret);
     cancel_os_thread(tid);
     Py_RETURN_NONE;
 }

--- a/tests/integration/gc_freeze_program.py
+++ b/tests/integration/gc_freeze_program.py
@@ -1,3 +1,4 @@
+# type: ignore
 import gc
 import sys
 import threading


### PR DESCRIPTION
closes #72
closes #46 

**Describe your changes**
- Add `check-manifest`, `sphinx-lint`, and `clang-format` to pre-commit setup (removing from `make`)
- Remove intermediary `make` commands
- Clean up `Makefile` and C files with linting
- Remove extra requirements absorbed into pre-commit
- Configure pre-push hook to run in CI

**Testing performed**
Reinstalled the hooks to allow for pre-commit and pre-push hooks. Running `pre-commit run --all-files` runs in the pre-commit stage so all but `check-manifest`. Running `pre-commit run --all-files --hook-stage pre-push` only runs `check-manifest`.
