### PR TITLE
Replace flake8 and move isort on Python files to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,23 +26,24 @@ repos:
       - id: rst-inline-touching-normal
         stages: [pre-commit]
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.262"
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        stages: [pre-commit]
+
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
         stages: [pre-commit]
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        stages: [pre-commit]
-        types: [file, python]
-
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
+        exclude_types: [python]
         stages: [pre-commit]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,16 @@ requires = [
 
 build-backend = 'setuptools.build_meta'
 
-[tool.isort]
+[tool.ruff]
+line-length = 95
+select = ["F", "E", "W", "I001"]
 
+[tool.ruff.isort]
+force-single-line = true
+known-first-party = ["pystack"]
+known-third-party=["rich", "elftools", "pytest"]
+
+[tool.isort]
 force_single_line = true
 multi_line_output = 3
 include_trailing_comma = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 95


### PR DESCRIPTION
Issue number of the reported bug or feature request: #45

**Describe your changes**
- Removed pre-commit check for flake8
- Removed setup.cfg (flake8 config)
- Added a pre-commit check for `ruff` that cover flake8 checks and isort for Python files
- Prevented isort pre-commit check from running on Python files

**Testing performed**
- Verified that ruff is fixing import order in .py and .pyi files (tested by introducing wrong order)
- Verified that ruff is fixing flake8 rules (tested by introducing unused import)

**Additional context**
Some `isort` options are not supported by `ruff`.

Option `multi_line_output = 3` (break multiple imports in multiple lines using parenthesis) is not supported by ruff. The default behavior is the same as `multi_line_output = 7` (all imports in one line without breaks), which used along `force-single-line = true` causes the multiple import to be split into individual imports. For example:
```
from collections import Counter, defaultdict, deque
```
is reformatted to:
```
from collections import Counter
from collections import defaultdict
from collections import deque
```
Options `include_trailing_comma = true` and `force_grid_wrap = 0` are related to `multi_line_output = 3` and are not applicable in ruff.

Option `use_parentheses = true` is also not supported by ruff, but because imports are in individual lines and `line-length = 95`, removing it would be very unlikely to cause problems.

Some references:
[Use Parentheses in isort documnentation](https://pycqa.github.io/isort/docs/configuration/options.html#use-parentheses)
[Multi Line Output Modes in isort documentation](https://pycqa.github.io/isort/docs/configuration/multi_line_output_modes.html)
[Flake 8 rules](https://www.flake8rules.com/)
[Ruff rules](https://beta.ruff.rs/docs/rules/)
