### PR TITLE
Use `mdformat` instead of `prettier`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,12 +39,10 @@ repos:
     hooks:
       - id: sphinx-lint
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+  - repo: https://github.com/executablebooks/mdformat/
+    rev: 0.7.16
     hooks:
-      - id: prettier
-        args: [--no-editorconfig]
-        exclude_types: [html]
+      - id: mdformat
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ process used by the Linux kernel, Samba, and many other major open source projec
 To participate under these terms, all that you must do is include a line like the following as the
 last line of the commit message for each commit in your contribution:
 
-    Signed-Off-By: Random J. Developer <random@developer.example.org>
+```
+Signed-Off-By: Random J. Developer <random@developer.example.org>
+```
 
 The simplest way to accomplish this is to add `-s` or `--signoff` to your `git commit` command.
 
@@ -37,7 +39,7 @@ API contract. In addition to being useful for generating documentation, docstrin
 looking through the source code or using the [built-in help][builtin-help] system, and can be
 leveraged in autocompletion by IDEs.
 
-Please see [PEP 257][] for details on semantics and conventions associated with Python docstrings.
+Please see [PEP 257] for details on semantics and conventions associated with Python docstrings.
 
 ### Docstring style
 
@@ -82,13 +84,6 @@ of the PR.
 
 <!-- LINKS -->
 
-[pep 257]: https://www.python.org/dev/peps/pep-0257/ "Docstring Conventions"
-[pep 484]: https://www.python.org/dev/peps/pep-0484/ "Type Hints"
-[google-style]:
-  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
-  "Example Google Style Python Docstrings"
 [builtin-help]: https://docs.python.org/3/library/functions.html#help
-
-<!--
-vim: tw=99:spell
--->
+[google-style]: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html "Example Google Style Python Docstrings"
+[pep 257]: https://www.python.org/dev/peps/pep-0257/ "Docstring Conventions"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://user-images.githubusercontent.com/11718525/226942590-de015c9a-4d5b-4960-9c42-8c1eac0845c1.png" width="70%">
 </p>
 
----
+______________________________________________________________________
 
 ![OS Linux](https://img.shields.io/badge/OS-Linux-blue)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pystack)
@@ -257,7 +257,9 @@ process used by the Linux kernel, Samba, and many other major open source projec
 To participate under these terms, all that you must do is include a line like the following as the
 last line of the commit message for each commit in your contribution:
 
-    Signed-Off-By: Random J. Developer <random@developer.example.org>
+```
+Signed-Off-By: Random J. Developer <random@developer.example.org>
+```
 
 The simplest way to accomplish this is to add `-s` or `--signoff` to your `git commit` command.
 


### PR DESCRIPTION
The only thing we've used `prettier` for is formatting Markdown for us.
But, `prettier` is implemented in Node, which isn't a tool chain and
ecosystem that we're terribly familiar with.

Instead, we can use the Python package `mdformat` to perform this
formatting for us.