### PR TITLE
Clean up references to unused tech

### DIFF
--- a/.github/workflows/lint_and_docs.yml
+++ b/.github/workflows/lint_and_docs.yml
@@ -14,7 +14,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -qy libdw-dev libelf-dev
-          npm install -g prettier
       - name: Install Python dependencies
         run: |
           python3 -m pip install -r requirements-extra.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt"
 RUN python3.10 -m venv /venv \
     && /venv/bin/python -m pip install -U pip wheel setuptools cython \
     && /venv/bin/python -m pip install -U -r /tmp/requirements-test.txt -r /tmp/requirements-extra.txt
-# RUN npm install -g prettier
-# RUN ln -s /opt/bb/bin/clang-format /usr/bin/clang-format
 
 ENV PYTHON=python3.10 \
     VIRTUAL_ENV="/venv" \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 exclude .clang-format
-exclude .prettierignore
 exclude CONTRIBUTING.md
 exclude Dockerfile
 exclude src/pystack/*.cpp
@@ -15,7 +14,6 @@ include README.md
 include src/pystack/py.typed
 include .bumpversion.cfg
 include .pre-commit-config.yaml
-include .prettierrc.yaml
 
 recursive-include src/pystack/_pystack *
 recursive-include src/pystack *.py

--- a/src/pystack/_pystack/CMakeLists.txt
+++ b/src/pystack/_pystack/CMakeLists.txt
@@ -4,8 +4,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-include_directories(/opt/bb/include/)
-
 find_package(PythonInterp 3.7 REQUIRED)
 find_package(PythonLibs 3.7 REQUIRED)
 IF(NOT PYTHONLIBS_FOUND OR NOT PYTHON_EXECUTABLE)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -218,10 +218,9 @@ def generate_all_pystack_combinations(
         if method == StackMethod.SYMBOLS and not python.has_symbols:
             continue
 
-        python_id = "bbpy" if "bbpy" in python.path.name else ""
         the_id = (
             f"method={method.name}, blocking={blocking}, "
-            f"python={python_id}{major_version}.{minor_version}"
+            f"python={major_version}.{minor_version}"
         )
 
         yield the_id, method, blocking, python[:2]


### PR DESCRIPTION
**Describe your changes**
Removed references to `bbpy`, `prettier`, or `/opt/bb/*` paths.

**Testing performed**
I found those with running `git grep -i bb` and `git grep -i prett` to ensure I'm not missing any, and no text files match.

**Additional context**
Some of the corefiles still mention `/opt/bb/*` folders in their compilation flags, but I don't think it matters.
