### PR TITLE
ci: Allow trailing whitespace in .bumpversion.cfg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: "^[.]bumpversion[.]cfg"
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0


### PR DESCRIPTION
`bump2version` wants to write lines with trailing whitespace, so we should treat this file as machine generated and accept that.
