### PR TITLE
ci: Skip aarch64 builds except for new releases

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,8 +30,20 @@ jobs:
         with:
           path: dist/*.tar.gz
 
+  choose_architectures:
+    name: Decide which architectures to build wheels for
+    runs-on: ubuntu-latest
+    steps:
+      - id: x86_64
+        run: echo "cibw_arch=x86_64" >> $GITHUB_OUTPUT
+      - id: aarch64
+        if: github.event_name == 'release' && github.event.action == 'published'
+        run: echo "cibw_arch=aarch64" >> $GITHUB_OUTPUT
+    outputs:
+      cibw_arches: ${{ toJSON(steps.*.outputs.cibw_arch) }}
+
   build_wheels:
-    needs: [build_sdist]
+    needs: [build_sdist, choose_architectures]
     name: Wheel for Linux-${{ matrix.cibw_python }}-${{ matrix.cibw_arch }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -39,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
-        cibw_arch: ["x86_64", "aarch64"]
+        cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
 
     steps:
       - name: Disable ptrace security restrictions


### PR DESCRIPTION
These builds are extremely slow due to needing to rely on emulation, and we can't adequately test them due to the emulation not providing all syscalls that we require. There's little point to wasting time building something that we can't test for every push to a PR branch, so we'll defer building these until the time a release is cut.
