### PR TITLE
Improve type safety for remote memory reads

### DIFF
--- a/src/pystack/_pystack/cpython/frame.h
+++ b/src/pystack/_pystack/cpython/frame.h
@@ -96,7 +96,7 @@ typedef struct _interpreter_frame
     PyObject* f_code;
     PyObject* frame_obj;
     struct _PyInterpreterFrame* previous;
-    _Py_CODEUNIT* f_lasti;
+    _Py_CODEUNIT* prev_instr;
     int stacktop;
     bool is_entry;
     char owner;

--- a/src/pystack/_pystack/process.h
+++ b/src/pystack/_pystack/process.h
@@ -68,59 +68,19 @@ class AbstractProcessManager : public std::enable_shared_from_this<AbstractProce
     int minorVersion() const;
     const python_v& offsets() const;
 
-    template<typename T, typename U, auto PMD0, auto PMD1>
-    inline auto& versionedField(const U& py_obj) const
+    template<typename OffsetsStruct, typename FieldPointer>
+    inline offset_t getFieldOffset(FieldPointer OffsetsStruct::*field) const
     {
-        offset_t offset = d_py_v->*PMD0.*PMD1;
-        return (*((T*)(((char*)&py_obj) + offset)));
+        return (d_py_v->get<OffsetsStruct>().*field).offset;
     }
 
-    template<typename T, auto PMD1>
-    inline auto& versionedThreadField(const PyThreadState& py_thread) const
+    template<typename OffsetsStruct, typename FieldPointer>
+    inline const typename FieldPointer::Type&
+    getField(const typename OffsetsStruct::Structure& obj, FieldPointer OffsetsStruct::*field) const
     {
-        return versionedField<T, PyThreadState, &python_v::py_thread, PMD1>(py_thread);
-    }
-
-    template<typename T, auto PMD1>
-    inline auto& versionedInterpreterStateField(const PyInterpreterState& py_is) const
-    {
-        return versionedField<T, PyInterpreterState, &python_v::py_is, PMD1>(py_is);
-    }
-
-    template<typename T, auto PMD1>
-    inline auto& versionedGcStatesField(const GCRuntimeState& py_gc) const
-    {
-        return versionedField<T, GCRuntimeState, &python_v::py_gc, PMD1>(py_gc);
-    }
-
-    template<typename T, auto PMD1>
-    inline auto& versionedFrameField(const PyFrameObject& py_frame) const
-    {
-        return versionedField<T, PyFrameObject, &python_v::py_frame, PMD1>(py_frame);
-    }
-
-    template<typename T, auto PMD1>
-    inline auto& versionedCodeField(const PyCodeObject& py_code) const
-    {
-        return versionedField<T, PyCodeObject, &python_v::py_code, PMD1>(py_code);
-    }
-
-    template<auto PMD1>
-    inline auto versionedCodeOffset() const
-    {
-        return d_py_v->py_code.*PMD1;
-    }
-
-    template<typename T, auto PMD1>
-    inline auto& versionedRuntimeField(const PyRuntimeState& py_runtime) const
-    {
-        return versionedField<T, PyRuntimeState, &python_v::py_runtime, PMD1>(py_runtime);
-    }
-
-    template<typename T, auto PMD1>
-    inline auto& versionedTypeField(const PyTypeObject& py_type) const
-    {
-        return versionedField<T, PyTypeObject, &python_v::py_type, PMD1>(py_type);
+        offset_t offset = getFieldOffset(field);
+        auto address = reinterpret_cast<const char*>(&obj) + offset;
+        return *reinterpret_cast<const typename FieldPointer::Type*>(address);
     }
 
   protected:

--- a/src/pystack/_pystack/pytypes.cpp
+++ b/src/pystack/_pystack/pytypes.cpp
@@ -516,9 +516,9 @@ Object::Object(const std::shared_ptr<const AbstractProcessManager>& manager, rem
     LOG(DEBUG) << std::hex << std::showbase << "Copying typeobject from address " << obj.ob_type;
     manager->copyMemoryFromProcess((remote_addr_t)obj.ob_type, manager->offsets().py_type.size, &cls);
 
-    d_flags = manager->versionedTypeField<unsigned long, &py_type_v::o_tp_flags>(cls);
+    d_flags = manager->getField(cls, &py_type_v::o_tp_flags);
 
-    remote_addr_t name_addr = manager->versionedTypeField<remote_addr_t, &py_type_v::o_tp_name>(cls);
+    remote_addr_t name_addr = manager->getField(cls, &py_type_v::o_tp_name);
     try {
         d_classname = manager->getCStringFromAddress(name_addr);
     } catch (RemoteMemCopyError& ex) {
@@ -689,7 +689,7 @@ Object::toConcreteObject() const
 std::string
 Object::guessClassName(PyTypeObject& type) const
 {
-    remote_addr_t tp_repr = d_manager->versionedTypeField<remote_addr_t, &py_type_v::o_tp_repr>(type);
+    remote_addr_t tp_repr = d_manager->getField(type, &py_type_v::o_tp_repr);
     if (tp_repr == d_manager->findSymbol("float_repr")) {
         return "float";
     }

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -50,6 +50,7 @@ py_frame()
             offsetof(T, f_back),
             offsetof(T, f_code),
             offsetof(T, f_lasti),
+            0,
             offsetof(T, f_localsplus)};
 }
 
@@ -60,7 +61,8 @@ py_framev311()
     return {sizeof(T),
             offsetof(T, previous),
             offsetof(T, f_code),
-            offsetof(T, f_lasti),
+            0,
+            offsetof(T, prev_instr),
             offsetof(T, localsplus),
             offsetof(T, is_entry)};
 }

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -9,73 +9,88 @@
 
 namespace pystack {
 typedef unsigned long offset_t;
+typedef uintptr_t remote_addr_t;
+
+template<typename T>
+struct FieldOffset
+{
+    typedef T Type;
+    offset_t offset;
+};
 
 struct py_code_v
 {
+    typedef PyCodeObject Structure;
     ssize_t size;
-    offset_t o_filename;
-    offset_t o_name;
-    offset_t o_lnotab;
-    offset_t o_firstlineno;
-    offset_t o_argcount;
-    offset_t o_varnames;
-    offset_t o_code_adaptive;
+    FieldOffset<remote_addr_t> o_filename;
+    FieldOffset<remote_addr_t> o_name;
+    FieldOffset<remote_addr_t> o_lnotab;
+    FieldOffset<unsigned int> o_firstlineno;
+    FieldOffset<unsigned int> o_argcount;
+    FieldOffset<remote_addr_t> o_varnames;
+    FieldOffset<char[1]> o_code_adaptive;
 };
 
 struct py_frame_v
 {
+    typedef PyFrameObject Structure;
     ssize_t size;
-    offset_t o_back;
-    offset_t o_code;
-    offset_t o_lasti;
-    offset_t o_localsplus;
-    offset_t o_is_entry;
+    FieldOffset<remote_addr_t> o_back;
+    FieldOffset<remote_addr_t> o_code;
+    FieldOffset<int> o_lasti;
+    FieldOffset<uintptr_t> o_prev_instr;
+    FieldOffset<PyObject* [1]> o_localsplus;
+    FieldOffset<bool> o_is_entry;
 };
 
 struct py_thread_v
 {
+    typedef PyThreadState Structure;
     ssize_t size;
-    offset_t o_prev;
-    offset_t o_next;
-    offset_t o_interp;
-    offset_t o_frame;
-    offset_t o_thread_id;
+    FieldOffset<remote_addr_t> o_prev;
+    FieldOffset<remote_addr_t> o_next;
+    FieldOffset<remote_addr_t> o_interp;
+    FieldOffset<remote_addr_t> o_frame;
+    FieldOffset<unsigned long> o_thread_id;
 };
 
 struct py_runtime_v
 {
+    typedef PyRuntimeState Structure;
     ssize_t size;
-    offset_t o_finalizing;
-    offset_t o_interp_head;
-    offset_t o_gc;
-    offset_t o_tstate_current;
+    FieldOffset<remote_addr_t> o_finalizing;
+    FieldOffset<remote_addr_t> o_interp_head;
+    FieldOffset<GCRuntimeState> o_gc;
+    FieldOffset<uintptr_t> o_tstate_current;
 };
 
 struct py_type_v
 {
+    typedef PyTypeObject Structure;
     ssize_t size;
-    offset_t o_tp_name;
-    offset_t o_tp_repr;
-    offset_t o_tp_flags;
+    FieldOffset<remote_addr_t> o_tp_name;
+    FieldOffset<remote_addr_t> o_tp_repr;
+    FieldOffset<unsigned long> o_tp_flags;
 };
 
-typedef struct
+struct py_is_v
 {
+    typedef PyInterpreterState Structure;
     ssize_t size;
-    offset_t o_next;
-    offset_t o_tstate_head;
-    offset_t o_gc;
-    offset_t o_modules;
-    offset_t o_sysdict;
-    offset_t o_builtins;
-} py_is_v;
+    FieldOffset<remote_addr_t> o_next;
+    FieldOffset<remote_addr_t> o_tstate_head;
+    FieldOffset<GCRuntimeState> o_gc;
+    FieldOffset<remote_addr_t> o_modules;
+    FieldOffset<remote_addr_t> o_sysdict;
+    FieldOffset<remote_addr_t> o_builtins;
+};
 
-typedef struct
+struct py_gc_v
 {
+    typedef GCRuntimeState Structure;
     ssize_t size;
-
-    offset_t o_collecting;
-} py_gc_v;
+    FieldOffset<remote_addr_t> o_collecting;
+};
 
 struct python_v
 {
@@ -86,7 +101,27 @@ struct python_v
     py_is_v py_is;
     py_runtime_v py_runtime;
     py_gc_v py_gc;
+
+    template<typename T>
+    inline const T& get() const;
 };
+
+#define define_python_v_get_specialization(T)                                                           \
+    template<>                                                                                          \
+    inline const T##_v& python_v::get<T##_v>() const                                                    \
+    {                                                                                                   \
+        return T;                                                                                       \
+    }
+
+define_python_v_get_specialization(py_type);
+define_python_v_get_specialization(py_code);
+define_python_v_get_specialization(py_frame);
+define_python_v_get_specialization(py_thread);
+define_python_v_get_specialization(py_is);
+define_python_v_get_specialization(py_runtime);
+define_python_v_get_specialization(py_gc);
+
+#undef define_python_v_get_specialization
 
 const python_v*
 getCPythonOffsets(int major, int minor);


### PR DESCRIPTION
Associate a type with every field of each structure that we are able to read from the remote process, and ensure that any reads of that field return the value as its associated type.