### PR TITLE
Add pkgconfig support in the setup.py

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
             python3.10-dbg
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip cython
+          python3 -m pip install --upgrade pip cython pkgconfig
           make test-install
       - name: Disable ptrace security restrictions
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,5 +74,6 @@
     "typeinfo": "cpp",
     "valarray": "cpp",
     "variant": "cpp"
-  }
+  },
+  "cmake.sourceDirectory": "/Users/pgalindo3/github/pystack/src/pystack/_pystack"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,5 @@
     "typeinfo": "cpp",
     "valarray": "cpp",
     "variant": "cpp"
-  },
-  "cmake.sourceDirectory": "/Users/pgalindo3/github/pystack/src/pystack/_pystack"
+  }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt"
 
 # Install Python packages
 RUN python3.10 -m venv /venv \
-    && /venv/bin/python -m pip install -U pip wheel setuptools cython \
+    && /venv/bin/python -m pip install -U pip wheel setuptools cython pkgconfig \
     && /venv/bin/python -m pip install -U -r /tmp/requirements-test.txt -r /tmp/requirements-extra.txt
 
 # Set environment variables

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ package.
 Check your package manager on how to install these dependencies (e.g.,
 `apt-get install libdw-dev libelf-dev` in Debian-based systems). Note that you may need to tell the
 compiler where to find the header and library files of the dependencies for the build to succeed.
-This is handled at Pystack level provided the users install pkg-config (e.g.,
-`apt-get install pkg-config` in Debian-based systems).
+If `pkg-config` is available (e.g. `apt-get install pkg-config` on Debian-based systems), it will
+automatically be used to locate the libraries and configure the correct build flags.
 Check your distribution's documentation to determine the location of the header and library files
 or for more detailed information. When building on Alpine Linux (or any other distribution that
 doesn't use glibc) you'll need elfutils 0.188 or newer. You may need to build this from source if

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ package.
 Check your package manager on how to install these dependencies (e.g.,
 `apt-get install libdw-dev libelf-dev` in Debian-based systems). Note that you may need to tell the
 compiler where to find the header and library files of the dependencies for the build to succeed.
+This is handled at Pystack level provided the users install pkg-config (e.g.,
+`apt-get install pkg-config` in Debian-based systems).
 Check your distribution's documentation to determine the location of the header and library files
 or for more detailed information. When building on Alpine Linux (or any other distribution that
 doesn't use glibc) you'll need elfutils 0.188 or newer. You may need to build this from source if

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@
 requires = [
      "setuptools",
      "wheel",
-     "Cython"
+     "Cython",
+     "pkgconfig"
 ]
 
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ library_flags = {"libraries": ["elf", "dw"]}
 
 try:
     library_flags = pkgconfig.parse("libelf libdw")
-    library_flags = {"libraries": library_flags["libraries"]}
 except EnvironmentError as e:
     print("pkg-config not found.", e)
     print("Falling back to static flags.")
@@ -81,12 +80,12 @@ PYSTACK_EXTENSION = setuptools.Extension(
         "src/pystack/_pystack/unwinder.cpp",
         "src/pystack/_pystack/version.cpp",
     ],
-    libraries=library_flags["libraries"],
     include_dirs=["src"],
     language="c++",
     extra_compile_args=["-std=c++17"],
     extra_link_args=["-std=c++17"],
     define_macros=DEFINE_MACROS,
+    **library_flags,
 )
 
 PYSTACK_EXTENSION.libraries.extend(["dl", "stdc++fs"])


### PR DESCRIPTION
Issue number of the reported bug or feature request: #54 

**Describe your changes**
I have added support for pkgconfig in setup.py. Python's pkgconfig depends on system package pkg-config. The instructions on how to install pkg-config has also been added to README.md. The changes uses pkgconfig to look for clfags & ldflags to use for libelf and libdw. If pkgconfig is unable to determine the flags then the default pre-configured behavior is used. 

**Testing performed**
Testing has been performed on Ubuntu 22.04.2 LTS

**Additional context**
-

Closes: https://github.com/bloomberg/pystack/issues/54