### PR TITLE
ci: Automatically publish docs for new releases

### DIFF
--- a/.github/workflows/lint_and_docs.yml
+++ b/.github/workflows/lint_and_docs.yml
@@ -28,3 +28,34 @@ jobs:
         run: |
           towncrier build --version 99.99 --name pystack --keep
           make docs
+
+  publish_docs:
+    name: Publish docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy libdw-dev libelf-dev pkg-config
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -r requirements-extra.txt
+      - name: Install Package
+        run: |
+          python3 -m pip install -e .
+      - name: Build docs
+        run: |
+          make docs
+      - name: Publish docs to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs/_build/html
+          single-commit: true


### PR DESCRIPTION
On each new release, automatically build our docs and publish them to GitHub Pages. The docs are also built by our linting workflow, but we don't attempt to reuse that build here, because the linting build runs `towncrier` with a phony version number in order to exercise the news fragments in the news/ directory, and we don't want that fake version in the changelog we publish.