### PR TITLE
ci: Update already installed Arch Linux packages

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -235,7 +235,7 @@ jobs:
           path: dist
       - name: Set up dependencies
         run: |
-          pacman -Sy --noconfirm \
+          pacman -Syu --noconfirm \
             gdb \
             gcc \
             file \


### PR DESCRIPTION
We seem to be installing a version of `libstdc++` that's incompatible with the version of glibc that the image shipped with.

The Arch Linux wiki says to avoid using `pacman -Sy` and to instead use `pacman -Syu`. Issues like this are probably why.
