### PR TITLE
ci: Allow publishing Python 3.12 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -301,10 +301,6 @@ jobs:
         with:
           name: artifact
           path: dist
-      - name: Avoid publishing Python 3.12 wheels
-        run: |
-          rm -f dist/*cp312*
-          ls -l dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip_existing: true


### PR DESCRIPTION
Python 3.12 is now ABI stable, so we should publish wheels for it.
