### PR TITLE
Stop telling setuptools our headers are in src/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ PYSTACK_EXTENSION = setuptools.Extension(
         "src/pystack/_pystack/unwinder.cpp",
         "src/pystack/_pystack/version.cpp",
     ],
-    include_dirs=["src"],
     language="c++",
     extra_compile_args=["-std=c++17"],
     extra_link_args=["-std=c++17"],


### PR DESCRIPTION
They're actually in `src/pystack/_pystack`, and the build works fine without passing this flag. Moreover, this flag causes builds to fail if `pkg-config` returns `include_dirs` for building against our dependencies, because we pass the `include_dirs` keyword argument twice.