### PR TITLE
Pin pyinstaller to avoid failure in Alpine

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 coverage[toml]
-pyinstaller
+pyinstaller<6.0
 pytest
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
Something in pyinstaller 6 is making the relocatable core fail in
Alpine. Meanwhile we investigate, pin pyinstaller to some version less
than 6 to get the CI green again.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
