### PR TITLE
Fix CI target for Fedora

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -204,8 +204,9 @@ jobs:
             g++ \
             file \
             python3 \
-            python3-devel \
-            python3-debug
+            python3-devel
+          dnf debuginfo-install -y \
+            python3
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip


### PR DESCRIPTION
Seems that the latest fedora image ships Python 3.12 with not enough
debugging symbols to provide native information for core files.
Apparently the python3-debug package only provides the debug version of
the runtime and doesn't also provide split-debug information for the
main executable.

Luckily, Fedora runs a debuginfod server that we can leverage to obtain
the debugging symbols that we need.
