### PR TITLE
Fix several issues uncovered while investigating recent CI failures

### DIFF
--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -87,7 +87,7 @@ class NativeReportingMode(enum.Enum):
     ALL = 1000
 
 
-cdef api void log_with_python(const char* message, int level):
+cdef api void log_with_python(const char* message, int level) noexcept:
     with contextlib.suppress(UnicodeDecodeError):
         LOGGER.log(level, message)
 

--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -87,9 +87,9 @@ class NativeReportingMode(enum.Enum):
     ALL = 1000
 
 
-cdef api void log_with_python(const char* message, int level) noexcept:
-    with contextlib.suppress(UnicodeDecodeError):
-        LOGGER.log(level, message)
+cdef api void log_with_python(const cppstring *message, int level) noexcept:
+    pymessage = _try_to_decode_string(message)
+    LOGGER.log(level, pymessage)
 
 T = TypeVar("T", bound=Callable[..., Any])
 

--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -654,8 +654,6 @@ def get_process_threads(
         method,
         native_mode,
     )
-    virtual_maps = list(generate_maps_for_process(pid))
-    map_info = parse_maps_file(pid, virtual_maps)
 
     try:
         with ProcessManager.create_from_pid(pid, stop_process) as manager:

--- a/src/pystack/_pystack/logging.cpp
+++ b/src/pystack/_pystack/logging.cpp
@@ -22,7 +22,7 @@ logWithPython(const std::string& message, int level)
         throw std::runtime_error("Logger is not initialized");
     }
     if (!PyErr_Occurred()) {
-        log_with_python(message.c_str(), level);
+        log_with_python(&message, level);
     }
 }
 

--- a/src/pystack/_pystack/mem.h
+++ b/src/pystack/_pystack/mem.h
@@ -179,26 +179,6 @@ class ProcessMemoryManager : public AbstractRemoteMemoryManager
     ssize_t readChunk(remote_addr_t addr, size_t len, char* dst) const;
 };
 
-class BlockingProcessMemoryManager : public ProcessMemoryManager
-{
-  public:
-    // Constructors
-    explicit BlockingProcessMemoryManager(
-            pid_t pid,
-            const std::vector<int>& tids,
-            const std::vector<VirtualMap>& vmaps);
-
-    // Destructors
-    ~BlockingProcessMemoryManager() override;
-
-  private:
-    // Data members
-    std::vector<int> d_tids;
-
-    // Methods
-    void detachFromProcess();
-};
-
 struct SimpleVirtualMap
 {
     uintptr_t start;

--- a/src/pystack/_pystack/mem.pxd
+++ b/src/pystack/_pystack/mem.pxd
@@ -14,11 +14,6 @@ cdef extern from "mem.h" namespace "pystack":
         ssize_t copyMemoryFromProcess(remote_addr_t addr, size_t size, void *destination) except+
 
 
-    cdef cppclass BlockingProcessMemoryManager(ProcessMemoryManager):
-        BlockingProcessMemoryManager(int pid, vector[int]d_tids) except+
-        ssize_t copyMemoryFromProcess(remote_addr_t addr, size_t size, void *destination) except+
-
-
     struct SimpleVirtualMap:
         uintptr_t start
         uintptr_t end

--- a/src/pystack/_pystack/process.cpp
+++ b/src/pystack/_pystack/process.cpp
@@ -119,6 +119,12 @@ ProcessTracer::~ProcessTracer()
     detachFromProcess();
 }
 
+std::vector<int>
+ProcessTracer::getTids() const
+{
+    return d_tids;
+}
+
 AbstractProcessManager::AbstractProcessManager(
         pid_t pid,
         std::vector<VirtualMap>&& memory_maps,
@@ -590,8 +596,12 @@ ProcessManager::ProcessManager(
         MemoryMapInformation map_info)
 : AbstractProcessManager(pid, std::move(memory_maps), std::move(map_info))
 , tracer(tracer)
-, d_tids(getProcessTids(pid))
 {
+    if (tracer) {
+        d_tids = tracer->getTids();
+    } else {
+        d_tids = getProcessTids(pid);
+    }
     d_manager = std::make_unique<ProcessMemoryManager>(pid, d_memory_maps);
     d_analyzer = analyzer;
     d_unwinder = std::make_unique<Unwinder>(analyzer);

--- a/src/pystack/_pystack/process.h
+++ b/src/pystack/_pystack/process.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <unistd.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -43,7 +44,7 @@ class ProcessTracer
 
   private:
     // Data members
-    std::vector<int> d_tids;
+    std::unordered_set<int> d_tids;
 
     // Methods
     void detachFromProcess();

--- a/src/pystack/_pystack/process.h
+++ b/src/pystack/_pystack/process.h
@@ -38,6 +38,9 @@ class ProcessTracer
     // Destructors
     ~ProcessTracer();
 
+    // Methods
+    std::vector<int> getTids() const;
+
   private:
     // Data members
     std::vector<int> d_tids;

--- a/src/pystack/_pystack/process.h
+++ b/src/pystack/_pystack/process.h
@@ -27,6 +27,25 @@ struct InvalidRemoteObject : public InvalidCopiedMemory
     }
 };
 
+class ProcessTracer
+{
+  public:
+    // Constructors
+    ProcessTracer(pid_t pid);
+    ProcessTracer(const ProcessTracer&) = delete;
+    ProcessTracer& operator=(const ProcessTracer&) = delete;
+
+    // Destructors
+    ~ProcessTracer();
+
+  private:
+    // Data members
+    std::vector<int> d_tids;
+
+    // Methods
+    void detachFromProcess();
+};
+
 class AbstractProcessManager : public std::enable_shared_from_this<AbstractProcessManager>
 {
   public:
@@ -118,7 +137,7 @@ class ProcessManager : public AbstractProcessManager
     // Constructors
     ProcessManager(
             pid_t pid,
-            bool blocking,
+            const std::shared_ptr<ProcessTracer>& tracer,
             const std::shared_ptr<ProcessAnalyzer>& analyzer,
             std::vector<VirtualMap> memory_maps,
             MemoryMapInformation map_info);
@@ -128,6 +147,7 @@ class ProcessManager : public AbstractProcessManager
 
   private:
     // Data members
+    std::shared_ptr<ProcessTracer> tracer;
     std::vector<int> d_tids;
 };
 

--- a/src/pystack/_pystack/process.pxd
+++ b/src/pystack/_pystack/process.pxd
@@ -17,6 +17,9 @@ cdef extern from "process.h" namespace "pystack::AbstractProcessManager":
         UNKNOWN
 
 cdef extern from "process.h" namespace "pystack":
+    cdef cppclass ProcessTracer:
+        pass
+
     cdef cppclass AbstractProcessManager:
         remote_addr_t scanBSS() except+
         remote_addr_t scanHeap() except+
@@ -30,7 +33,7 @@ cdef extern from "process.h" namespace "pystack":
         void setPythonVersion(pair[int, int] version)
 
     cdef cppclass ProcessManager(AbstractProcessManager):
-        ProcessManager(int pid, int blocking, shared_ptr[ProcessAnalyzer] analyzer, vector[VirtualMap] memory_maps, MemoryMapInformation map_info) except+
+        ProcessManager(int pid, shared_ptr[ProcessTracer] tracer, shared_ptr[ProcessAnalyzer] analyzer, vector[VirtualMap] memory_maps, MemoryMapInformation map_info) except+
 
     cdef cppclass CoreFileProcessManager(AbstractProcessManager):
         CoreFileProcessManager(int pid, shared_ptr[CoreFileAnalyzer] analyzer, vector[VirtualMap] memory_maps, MemoryMapInformation map_info) except+


### PR DESCRIPTION
This fixes several issues, predominantly around how we handle mappings that are created or destroyed while we're actively trying to attach, or threads that are started and stopped while we're still in the process of attaching.