### PR TITLE
Update `upload-artifact` and `download-artifact`: one artifact per arch + platform tag series

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,26 +29,27 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
-  choose_architectures:
-    name: Decide which architectures to build wheels for
+  choose_wheel_types:
+    name: Decide which wheel types to build
     runs-on: ubuntu-latest
     steps:
-      - id: x86_64
-        run: echo "cibw_arch=x86_64" >> $GITHUB_OUTPUT
-      - id: aarch64
-        run: echo "cibw_arch=aarch64" >> $GITHUB_OUTPUT
+      - id: manylinux_x86_64
+        run: echo "wheel_types=manylinux_x86_64" >> $GITHUB_OUTPUT
+      - id: musllinux_x86_64
+        run: echo "wheel_types=musllinux_x86_64" >> $GITHUB_OUTPUT
+      - id: manylinux_aarch64
+        run: echo "wheel_types=manylinux_aarch64" >> $GITHUB_OUTPUT
     outputs:
-      cibw_arches: ${{ toJSON(steps.*.outputs.cibw_arch) }}
+      wheel_types: ${{ toJSON(steps.*.outputs.wheel_types) }}
 
   build_wheels:
-    needs: [build_sdist, choose_architectures]
-    name: Wheel for Linux ${{ matrix.cibw_arch }}
-    runs-on: ${{ matrix.os }}
+    needs: [build_sdist, choose_wheel_types]
+    name: ${{ matrix.wheel_type }} wheels
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
+        wheel_type: ${{ fromJSON(needs.choose_wheel_types.outputs.wheel_types) }}
 
     steps:
       - name: Disable ptrace security restrictions
@@ -66,12 +67,12 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: "cp3{7..12}-*"
-          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
+          CIBW_BUILD: "cp3{7..12}-${{ matrix.wheel_type }}"
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_PRERELEASE_PYTHONS: True
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.cibw_arch }}-wheels
+          name: ${{ matrix.wheel_type }}-wheels
           path: ./wheelhouse/*.whl
 
   test_attaching_to_old_interpreters:
@@ -85,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: "x86_64-wheels"
+          name: "manylinux_x86_64-wheels"
           path: dist
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -127,7 +128,7 @@ jobs:
           python-version: "${{matrix.python_version}}-dev"
       - uses: actions/download-artifact@v4
         with:
-          name: "x86_64-wheels"
+          name: "manylinux_x86_64-wheels"
           path: dist
       - name: Set up dependencies
         run: |
@@ -168,7 +169,7 @@ jobs:
           apk add --update alpine-sdk bash alpine-sdk python3 python3-dev gdb musl-dbg python3-dbg
       - uses: actions/download-artifact@v4
         with:
-          name: "x86_64-wheels"
+          name: "musllinux_x86_64-wheels"
           path: dist
       - name: Install Python dependencies
         run: |
@@ -205,7 +206,7 @@ jobs:
             python3
       - uses: actions/download-artifact@v4
         with:
-          name: "x86_64-wheels"
+          name: "manylinux_x86_64-wheels"
           path: dist
       - name: Install Python dependencies
         run: |
@@ -240,7 +241,7 @@ jobs:
             python-wheel
       - uses: actions/download-artifact@v4
         with:
-          name: "x86_64-wheels"
+          name: "manylinux_x86_64-wheels"
           path: dist
       - name: Install Python dependencies
         run: |
@@ -278,7 +279,7 @@ jobs:
             python3-distutils
       - uses: actions/download-artifact@v4
         with:
-          name: "x86_64-wheels"
+          name: "manylinux_x86_64-wheels"
           path: dist
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -38,6 +38,7 @@ jobs:
       - id: musllinux_x86_64
         run: echo "wheel_types=musllinux_x86_64" >> $GITHUB_OUTPUT
       - id: manylinux_aarch64
+        if: github.event_name == 'release' && github.event.action == 'published'
         run: echo "wheel_types=manylinux_aarch64" >> $GITHUB_OUTPUT
     outputs:
       wheel_types: ${{ toJSON(steps.*.outputs.wheel_types) }}
@@ -295,6 +296,7 @@ jobs:
   upload_pypi:
     needs: [test_wheels]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -304,4 +306,8 @@ jobs:
           mv dist/sdist/*.tar.gz dist/
           mv dist/*-wheels/*.whl dist/
           rmdir dist/{sdist,*-wheels}
-      - run: ls -R dist
+          ls -R dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   choose_architectures:
@@ -35,20 +36,18 @@ jobs:
       - id: x86_64
         run: echo "cibw_arch=x86_64" >> $GITHUB_OUTPUT
       - id: aarch64
-        if: github.event_name == 'release' && github.event.action == 'published'
         run: echo "cibw_arch=aarch64" >> $GITHUB_OUTPUT
     outputs:
       cibw_arches: ${{ toJSON(steps.*.outputs.cibw_arch) }}
 
   build_wheels:
     needs: [build_sdist, choose_architectures]
-    name: Wheel for Linux-${{ matrix.cibw_python }}-${{ matrix.cibw_arch }}
+    name: Wheel for Linux ${{ matrix.cibw_arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_arch: ${{ fromJSON(needs.choose_architectures.outputs.cibw_arches) }}
 
     steps:
@@ -58,20 +57,21 @@ jobs:
       - uses: docker/setup-qemu-action@v3
         if: runner.os == 'Linux'
         name: Set up QEMU
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: sdist
       - name: Extract sdist
         run: |
           tar zxvf *.tar.gz --strip-components=1
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_BUILD: "cp3{7..12}-*"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_PRERELEASE_PYTHONS: True
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.cibw_arch }}-wheels
           path: ./wheelhouse/*.whl
 
   test_attaching_to_old_interpreters:
@@ -83,9 +83,9 @@ jobs:
         python_version: ["2.7", "3.6"]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: "x86_64-wheels"
           path: dist
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -121,14 +121,14 @@ jobs:
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "${{matrix.python_version}}-dev"
+      - uses: actions/download-artifact@v4
+        with:
+          name: "x86_64-wheels"
+          path: dist
       - name: Set up dependencies
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
@@ -163,13 +163,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
       - name: Set up dependencies
         run: |
           apk add --update alpine-sdk bash alpine-sdk python3 python3-dev gdb musl-dbg python3-dbg
+      - uses: actions/download-artifact@v4
+        with:
+          name: "x86_64-wheels"
+          path: dist
       - name: Install Python dependencies
         run: |
           python3 -m venv venv
@@ -193,10 +193,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
       - name: Set up dependencies
         run: |
           dnf install -y \
@@ -207,6 +203,10 @@ jobs:
             python3-devel
           dnf debuginfo-install -y \
             python3
+      - uses: actions/download-artifact@v4
+        with:
+          name: "x86_64-wheels"
+          path: dist
       - name: Install Python dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -228,10 +228,6 @@ jobs:
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
       - name: Set up dependencies
         run: |
           pacman -Syu --noconfirm \
@@ -242,6 +238,10 @@ jobs:
             python-pip \
             python-setuptools \
             python-wheel
+      - uses: actions/download-artifact@v4
+        with:
+          name: "x86_64-wheels"
+          path: dist
       - name: Install Python dependencies
         run: |
           python -m venv venv
@@ -265,10 +265,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
       - name: Set up dependencies
         run: |
           apt-get update
@@ -280,6 +276,10 @@ jobs:
             python3-venv \
             python3-dbg \
             python3-distutils
+      - uses: actions/download-artifact@v4
+        with:
+          name: "x86_64-wheels"
+          path: dist
       - name: Install Python dependencies
         run: |
           python3 -m venv venv
@@ -294,13 +294,13 @@ jobs:
   upload_pypi:
     needs: [test_wheels]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          # with no name set, it downloads all of the artifacts
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip_existing: true
-          password: ${{ secrets.PYPI_PASSWORD }}
+      - run: |
+          mv dist/sdist/*.tar.gz dist/
+          mv dist/*-wheels/*.whl dist/
+          rmdir dist/{sdist,*-wheels}
+      - run: ls -R dist


### PR DESCRIPTION
Another approach for #161 where we use one artifact per architecture + platform tag series instead of one per wheel.
