### PR TITLE
Allow spinning a Memray environment up in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "PyStack Dockerfile",
+  "build": {
+    "context": "..",
+    "dockerfile": "../Dockerfile"
+  },
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "onCreateCommand": "pip install -e ."
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,9 @@ RUN apt-get update \
     python3.11-dev \
     python3.11-dbg \
     python3.11-distutils \
-    python3.10-full \
+    python3.12-dev \
+    python3.12-dbg \
+    python3.12-venv \
     make \
     cmake \
     gdb \
@@ -80,12 +82,12 @@ COPY --from=elfutils_builder /usr /usr
 COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt", "/tmp/"]
 
 # Install Python packages
-RUN python3.10 -m venv /venv \
+RUN python3.12 -m venv /venv \
     && /venv/bin/python -m pip install -U pip wheel setuptools cython pkgconfig \
     && /venv/bin/python -m pip install -U -r /tmp/requirements-test.txt -r /tmp/requirements-extra.txt
 
 # Set environment variables
-ENV PYTHON=python3.10 \
+ENV PYTHON=python3.12 \
     VIRTUAL_ENV="/venv" \
     PATH="/venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,14 @@ RUN apt-get update \
         bison \
         pkg-config \
         libarchive-dev \
-        libmicrohttpd-dev \
         libcurl4-gnutls-dev \
-        libsqlite3-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /elfutils \
     && cd /elfutils \
     && curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2 \
-    && tar -xf elfutils.tar.bz2 \
-    && cd elfutils-$VERS \
-    && CFLAGS='-w -DFNM_EXTMATCH=0' ./configure --prefix=/usr --disable-nls --disable-libdebuginfod --disable-debuginfod --with-zstd \
+    && tar -xf elfutils.tar.bz2 --strip-components 1 \
+    && CFLAGS='-w' ./configure --prefix=/usr/local --disable-nls --disable-debuginfod --enable-libdebuginfod=dummy --with-zstd \
     && make install
 
 # Stage 2: Final stage
@@ -72,11 +69,15 @@ RUN apt-get update \
     valgrind \
     lcov \
     file \
+    libzstd-dev \
+    liblzma-dev \
+    libbz2-dev \
+    zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the installed files from the elfutils_builder stage
-COPY --from=elfutils_builder /usr /usr
+COPY --from=elfutils_builder /usr/local /usr/local
 
 # Copy the required files
 COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt", "/tmp/"]
@@ -91,7 +92,8 @@ ENV PYTHON=python3.12 \
     VIRTUAL_ENV="/venv" \
     PATH="/venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
-    TZ=UTC
+    TZ=UTC \
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 # Set the working directory
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,14 +79,6 @@ RUN apt-get update \
 # Copy the installed files from the elfutils_builder stage
 COPY --from=elfutils_builder /usr/local /usr/local
 
-# Copy the required files
-COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt", "/tmp/"]
-
-# Install Python packages
-RUN python3.12 -m venv /venv \
-    && /venv/bin/python -m pip install -U pip wheel setuptools cython pkgconfig \
-    && /venv/bin/python -m pip install -U -r /tmp/requirements-test.txt -r /tmp/requirements-extra.txt
-
 # Set environment variables
 ENV PYTHON=python3.12 \
     VIRTUAL_ENV="/venv" \
@@ -94,6 +86,14 @@ ENV PYTHON=python3.12 \
     PYTHONDONTWRITEBYTECODE=1 \
     TZ=UTC \
     PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+# Copy the required files
+COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt", "/tmp/"]
+
+# Install Python packages
+RUN python3.12 -m venv $VIRTUAL_ENV \
+    && pip install -U pip wheel setuptools cython pkgconfig \
+    && pip install -U -r /tmp/requirements-test.txt -r /tmp/requirements-extra.txt
 
 # Set the working directory
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,11 @@ RUN apt-get update \
     make \
     cmake \
     gdb \
+    git \
     valgrind \
     lcov \
     file \
+    less \
     libzstd-dev \
     liblzma-dev \
     libbz2-dev \


### PR DESCRIPTION
Update our Dockerfile to exercise Python 3.12, and add a devcontainer.json based on it, with our build and test dependencies installed.