### PR TITLE
Add gzip support

### DIFF
--- a/docs/corefile.rst
+++ b/docs/corefile.rst
@@ -37,6 +37,8 @@ In most cases, you just need to provide the location of the core to use PyStack 
         (Python) File "/test.py", line 16, in third_func
             time.sleep(1000)
 
+Pystack can automatically extract core dumps from `.gz` files: `pystack core ./archived_core_file.gz`
+
 To learn more about the different options you can use to customize what is reported, check the :ref:`customizing-the-reports` section.
 
 Providing the executable

--- a/news/add_gzip_support.rst
+++ b/news/add_gzip_support.rst
@@ -1,0 +1,4 @@
+Features
+~~~~~~~~
+
+- Add support for Gzip compressed corefiles (#171)

--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -1,9 +1,11 @@
 import argparse
+import gzip
 import logging
 import os
 import pathlib
 import signal
 import sys
+import tempfile
 from contextlib import suppress
 from textwrap import dedent
 from typing import Any
@@ -319,6 +321,19 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
     if not corefile.exists():
         parser.error(f"Core {corefile} does not exist")
 
+    temp_file = None
+    if corefile.suffix == ".gz":
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            with gzip.open(corefile, "rb") as fp:
+                while chunk := fp.read(4 * 1024 * 1024):
+                    temp_file.write(chunk)
+        except gzip.BadGzipFile:
+            parser.error(f"Core {corefile} is not a valid gzip file")
+        finally:
+            temp_file.close()
+        corefile = pathlib.Path(temp_file.name)
+
     if args.executable is None:
         corefile_analyzer = CoreFileAnalyzer(corefile)
         executable = pathlib.Path(corefile_analyzer.extract_executable())
@@ -379,6 +394,10 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
     ):
         native = args.native_mode != NativeReportingMode.OFF
         print_thread(thread, native)
+
+    # Delete temporary file created if corefile is a gzip.
+    if temp_file:
+        pathlib.Path(temp_file.name).unlink()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -321,12 +321,11 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
     if not corefile.exists():
         parser.error(f"Core {corefile} does not exist")
 
-    temp_file = None
     if corefile.suffix == ".gz":
         temp_file = tempfile.NamedTemporaryFile(delete=False)
         try:
-            with gzip.open(corefile, "rb") as fp:
-                while chunk := fp.read(4 * 1024 * 1024):
+            with gzip.open(corefile, "rb") as file_handle:
+                while chunk := file_handle.read(4 * 1024 * 1024):
                     temp_file.write(chunk)
         except gzip.BadGzipFile:
             parser.error(f"Core {corefile} is not a valid gzip file")
@@ -394,10 +393,6 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
     ):
         native = args.native_mode != NativeReportingMode.OFF
         print_thread(thread, native)
-
-    # Delete temporary file created if corefile is a gzip.
-    if temp_file:
-        pathlib.Path(temp_file.name).unlink()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/pystack/process.py
+++ b/src/pystack/process.py
@@ -165,6 +165,9 @@ def decompress_gzip(
     """
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         with gzip.open(filename, "rb") as file_handle:
-            while chunk := file_handle.read(chunk_size):
+            while True:
+                chunk = file_handle.read(chunk_size)
+                if not chunk:
+                    break
                 temp_file.write(chunk)
     return pathlib.Path(temp_file.name)

--- a/src/pystack/process.py
+++ b/src/pystack/process.py
@@ -1,7 +1,9 @@
+import gzip
 import logging
 import pathlib
 import re
 import subprocess
+import tempfile
 from typing import Optional
 from typing import Tuple
 
@@ -129,3 +131,40 @@ def get_thread_name(pid: int, tid: int) -> Optional[str]:
             return comm.read().strip()
     except OSError:
         return None
+
+
+def is_gzip(filename: pathlib.Path) -> bool:
+    """
+    Checks if the given file is a Gzip file based on the header.
+
+    Args:
+        filename (pathlib.Path): The path to the file to be checked.
+
+    Returns:
+        bool: True if the file starts with the Gzip header, False otherwise.
+    """
+    gzip_header = b"\x1f\x8b"
+    with open(filename, "rb") as thefile:
+        return thefile.read(2) == gzip_header
+
+
+def decompress_gzip(
+    filename: pathlib.Path, chunk_size: int = 4 * 1024 * 1024
+) -> pathlib.Path:
+    """Decompresses a Gzip file and writes the contents to a temporary file.
+
+    Args:
+        filename: The path to the gzip file to decompress.
+        chunk_size: Size of chunks to read and write at a time; defaults to 4MB.
+
+    Returns:
+        The path to the temporary file containing the decompressed data.
+
+    Raises:
+        gzip.BadGzipFile: If the file is not a valid gzip file.
+    """
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        with gzip.open(filename, "rb") as file_handle:
+            while chunk := file_handle.read(chunk_size):
+                temp_file.write(chunk)
+    return pathlib.Path(temp_file.name)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -464,14 +464,14 @@ def test_process_core_default_gzip_without_executable():
             "extracted_executable"
         )
         get_process_threads_mock.return_value = threads
-        tempfile_mock.return_value.name = Path("corefile.gz")
+        tempfile_mock.return_value.name = Path("/tmp/file")
 
         main()
 
     # THEN
 
     get_process_threads_mock.assert_called_with(
-        Path("corefile.gz"),
+        Path("/tmp/file"),
         Path("extracted_executable"),
         library_search_path="",
         native_mode=NativeReportingMode.OFF,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -456,8 +456,6 @@ def test_process_core_default_gzip_without_executable():
     ) as gzip_open_mock, patch(
         "tempfile.NamedTemporaryFile"
     ) as tempfile_mock, patch(
-        "pystack.__main__.os.unlink", return_value=None
-    ), patch(
         "pystack.__main__.CoreFileAnalyzer"
     ) as core_file_analizer_mock:
         core_file_analizer_mock().extract_executable.return_value = (


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #168 *

**Describe your changes**
Add check for core dump file ending in `.gz`. If so, decompress to temporary file and run analyzer on temporary file.

**Testing performed**
Added a unit test following the pattern of current tests. It mocks calls to `gzip` and `tempfile`, asserts that the analyzer was called with the correct path. It does not test for any failure modes, and really only tests the mocks. Happy to add more tests if requested.

**Additional context**

