### PR TITLE
Enable debuginfod support when testing wheels in Arch Linux

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -239,7 +239,9 @@ jobs:
             python \
             python-pip \
             python-setuptools \
-            python-wheel
+            python-wheel \
+            elfutils \
+            debuginfod
       - uses: actions/download-artifact@v4
         with:
           name: "manylinux_x86_64-wheels"
@@ -253,6 +255,7 @@ jobs:
       - name: Run pytest
         env:
           PYTHON_TEST_VERSION: "auto"
+          DEBUGINFOD_URLS: "https://debuginfod.archlinux.org"
         run: venv/bin/python -m pytest tests -k 'not 2.7' -n auto -vvv
 
   test_wheels_in_debian:

--- a/src/pystack/traceback_formatter.py
+++ b/src/pystack/traceback_formatter.py
@@ -110,4 +110,3 @@ def _format_merged_stacks(
             raise ValueError(
                 f"Invalid frame type: {frame_type(frame, thread.python_version)}"
             )
-    return current_frame


### PR DESCRIPTION
Arch is more aggressively stripping out binaries and the tests that rely
on debug symbols fail due to insufficient debugging information. Getting
these debugging symbols by hand is a bit of a mess because Arch doesn't
publish debug packages in the same index. On the other hand Arch
provides a debuginfod server, so we can leverage that when running the
tests.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
