### PR TITLE
Create native last mode

### DIFF
--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -161,6 +161,15 @@ def generate_cli_parser() -> argparse.ArgumentParser:
         "the interpreter (implies --native)",
     )
     remote_parser.add_argument(
+        "--native-last",
+        action="store_const",
+        dest="native_mode",
+        const=NativeReportingMode.LAST,
+        default=NativeReportingMode.OFF,
+        help="Include native (C) frames only after the last python frame "
+        "in the resulting stack trace",
+    )
+    remote_parser.add_argument(
         "--locals",
         action="store_true",
         default=False,
@@ -205,6 +214,15 @@ def generate_cli_parser() -> argparse.ArgumentParser:
         default=NativeReportingMode.OFF,
         help="Include native (C) frames from threads not registered with "
         "the interpreter (implies --native)",
+    )
+    core_parser.add_argument(
+        "--native-last",
+        action="store_const",
+        dest="native_mode",
+        const=NativeReportingMode.LAST,
+        default=NativeReportingMode.OFF,
+        help="Include native (C) frames only after the last python frame "
+        "in the resulting stack trace",
     )
     core_parser.add_argument(
         "--locals",

--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -287,7 +287,8 @@ def process_remote(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
         method=StackMethod.ALL if args.exhaustive else StackMethod.AUTO,
     ):
         native = args.native_mode != NativeReportingMode.OFF
-        print_thread(thread, native)
+        only_last_native_frames = args.native_mode == NativeReportingMode.LAST
+        print_thread(thread, native, only_last_native_frames)
 
 
 def format_psinfo_information(psinfo: Dict[str, Any]) -> str:
@@ -396,7 +397,8 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
         method=StackMethod.ALL if args.exhaustive else StackMethod.AUTO,
     ):
         native = args.native_mode != NativeReportingMode.OFF
-        print_thread(thread, native)
+        only_last_native_frames = args.native_mode == NativeReportingMode.LAST
+        print_thread(thread, native, only_last_native_frames)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/pystack/_pystack.pyi
+++ b/src/pystack/_pystack.pyi
@@ -26,6 +26,7 @@ class NativeReportingMode(enum.Enum):
     ALL: int
     OFF: int
     PYTHON: int
+    LAST: int
 
 class StackMethod(enum.Enum):
     ALL: int

--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -85,6 +85,7 @@ class NativeReportingMode(enum.Enum):
     OFF = 0
     PYTHON = 1
     ALL = 1000
+    LAST = 2000
 
 
 cdef api void log_with_python(const cppstring *message, int level) noexcept:

--- a/src/pystack/traceback_formatter.py
+++ b/src/pystack/traceback_formatter.py
@@ -11,8 +11,10 @@ from .types import PyThread
 from .types import frame_type
 
 
-def print_thread(thread: PyThread, native: bool) -> None:
-    for line in format_thread(thread, native):
+def print_thread(
+    thread: PyThread, native: bool, only_last_native_frames: bool = False
+) -> None:
+    for line in format_thread(thread, native, only_last_native_frames):
         print(line, file=sys.stdout, flush=True)
 
 
@@ -62,7 +64,9 @@ def _are_the_stacks_mergeable(thread: PyThread) -> bool:
     return n_eval_frames == n_entry_frames
 
 
-def format_thread(thread: PyThread, native: bool) -> Iterable[str]:
+def format_thread(
+    thread: PyThread, native: bool, only_last_native_frames: bool = False
+) -> Iterable[str]:
     current_frame: Optional[PyFrame] = thread.frame
     if current_frame is None and not native:
         yield f"The frame stack for thread {thread.tid} is empty"
@@ -81,11 +85,53 @@ def format_thread(thread: PyThread, native: bool) -> Iterable[str]:
             yield from format_frame(current_frame)
             current_frame = current_frame.next
     else:
-        yield from _format_merged_stacks(thread, current_frame)
+        yield from _format_merged_stacks(thread, current_frame, only_last_native_frames)
     yield ""
 
 
 def _format_merged_stacks(
+    thread: PyThread,
+    current_frame: Optional[PyFrame],
+    only_last_native_frames: bool = False,
+) -> Iterable[str]:
+    if only_last_native_frames:
+        return _format_last_frames(thread, current_frame)
+    else:
+        return _format_all_frames(thread, current_frame)
+
+
+def _format_last_frames(
+    thread: PyThread, current_frame: Optional[PyFrame]
+) -> Iterable[str]:
+    other_frames_list: list[str] = []
+    for frame in thread.native_frames:
+        if frame_type(frame, thread.python_version) == NativeFrame.FrameType.EVAL:
+            assert current_frame is not None
+            other_frames_list = []
+            yield from format_frame(current_frame)
+            current_frame = current_frame.next
+            while current_frame and not current_frame.is_entry:
+                yield from format_frame(current_frame)
+                current_frame = current_frame.next
+            continue
+        elif frame_type(frame, thread.python_version) == NativeFrame.FrameType.IGNORE:
+            continue
+        elif frame_type(frame, thread.python_version) == NativeFrame.FrameType.OTHER:
+            function = colored(frame.symbol, "yellow")
+            other_frames_list.append(
+                f'    {colored("(C)", "blue")} File "{frame.path}",'
+                f" line {frame.linenumber},"
+                f" in {function} ({colored(frame.library, attrs=['faint'])})"
+            )
+        else:  # pragma: no cover
+            raise ValueError(
+                f"Invalid frame type: {frame_type(frame, thread.python_version)}"
+            )
+    for stringified_frame in other_frames_list:
+        yield stringified_frame
+
+
+def _format_all_frames(
     thread: PyThread, current_frame: Optional[PyFrame]
 ) -> Iterable[str]:
     for frame in thread.native_frames:

--- a/tests/unit/test_traceback_formatter.py
+++ b/tests/unit/test_traceback_formatter.py
@@ -71,7 +71,7 @@ def test_traceback_formatter_no_native():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -98,7 +98,7 @@ def test_traceback_formatter_no_frames_no_native():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -126,7 +126,7 @@ def test_traceback_formatter_no_frames_native():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
     assert lines == [
@@ -163,7 +163,7 @@ def test_traceback_formatter_no_frames_native_with_eval_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
     assert lines == [
@@ -225,7 +225,7 @@ def test_traceback_formatter_no_mergeable_native_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
     assert lines == [
@@ -294,7 +294,7 @@ def test_traceback_formatter_with_source():
     with patch("builtins.open", mock_open(read_data=source_data)), patch(
         "os.path.exists", return_value=True
     ):
-        lines = list(format_thread(thread, native=False))
+        lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -369,7 +369,7 @@ def test_traceback_formatter_native_matching_simple_eval_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
 
@@ -457,7 +457,7 @@ def test_traceback_formatter_native_matching_composite_eval_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
 
@@ -571,7 +571,7 @@ def test_traceback_formatter_native_matching_eval_frames_ignore_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
 
@@ -616,7 +616,7 @@ def test_traceback_formatter_gil_detection():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -655,7 +655,7 @@ def test_traceback_formatter_gc_detection_with_native():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -692,7 +692,7 @@ def test_traceback_formatter_gc_detection_without_native():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -738,7 +738,7 @@ def test_traceback_formatter_dropping_the_gil_detection():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -784,7 +784,7 @@ def test_traceback_formatter_taking_the_gil_detection():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -846,7 +846,7 @@ def test_traceback_formatter_native_not_matching_simple_eval_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -923,7 +923,7 @@ def test_traceback_formatter_native_not_matching_composite_eval_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 
@@ -1004,7 +1004,7 @@ def test_traceback_formatter_mixed_inlined_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
 
@@ -1086,7 +1086,7 @@ def test_traceback_formatter_all_inlined_frames():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=True))
+    lines = list(format_thread(thread, native=True, only_last_native_frames=False))
 
     # THEN
 
@@ -1099,6 +1099,89 @@ def test_traceback_formatter_all_inlined_frames():
         '    (Python) File "file4.py", line 4, in function4',
         '    (Python) File "file5.py", line 5, in function5',
         '    (C) File "native_file3.c", line 3, in native_function3 (library.so)',
+        "",
+    ]
+    assert lines == expected_lines
+
+
+def test_traceback_formatter_only_last_native_frames():
+    # GIVEN
+
+    codes = [
+        PyCodeObject(
+            filename="file1.py",
+            scope="function1",
+            location=LocationInfo(1, 1, 0, 0),
+        ),
+        PyCodeObject(
+            filename="file2.py",
+            scope="function2",
+            location=LocationInfo(2, 2, 0, 0),
+        ),
+        PyCodeObject(
+            filename="file3.py",
+            scope="function3",
+            location=LocationInfo(3, 3, 0, 0),
+        ),
+        PyCodeObject(
+            filename="file4.py",
+            scope="function4",
+            location=LocationInfo(4, 4, 0, 0),
+        ),
+        PyCodeObject(
+            filename="file5.py",
+            scope="function5",
+            location=LocationInfo(5, 5, 0, 0),
+        ),
+    ]
+
+    current_frame = None
+    for code in reversed(codes):
+        current_frame = PyFrame(
+            prev=None,
+            next=current_frame,
+            code=code,
+            arguments={},
+            locals={},
+            is_entry=False,
+        )
+    current_frame.is_entry = True
+
+    native_frames = [
+        NativeFrame(0x0, "native_function1", "native_file1.c", 1, 0, "library.so"),
+        NativeFrame(0x1, "PyEval_EvalFrameEx", "Python/ceval.c", 123, 0, "library.so"),
+        NativeFrame(0x3, "native_function2", "native_file2.c", 2, 0, "library.so"),
+        NativeFrame(
+            0x2, "_PyEval_EvalFrameDefault", "Python/ceval.c", 12, 0, "library.so"
+        ),
+        NativeFrame(0x4, "native_function3", "native_file3.c", 3, 0, "library.so"),
+        NativeFrame(0x6, "native_function4", "native_file4.c", 4, 0, "library.so"),
+    ]
+
+    thread = PyThread(
+        tid=1,
+        frame=current_frame,
+        native_frames=native_frames,
+        holds_the_gil=False,
+        is_gc_collecting=False,
+        python_version=(3, 8),
+    )
+
+    # WHEN
+
+    lines = list(format_thread(thread, native=True, only_last_native_frames=True))
+
+    # THEN
+
+    expected_lines = [
+        "Traceback for thread 1 [] (most recent call last):",
+        '    (Python) File "file1.py", line 1, in function1',
+        '    (Python) File "file2.py", line 2, in function2',
+        '    (Python) File "file3.py", line 3, in function3',
+        '    (Python) File "file4.py", line 4, in function4',
+        '    (Python) File "file5.py", line 5, in function5',
+        '    (C) File "native_file3.c", line 3, in native_function3 (library.so)',
+        '    (C) File "native_file4.c", line 4, in native_function4 (library.so)',
         "",
     ]
     assert lines == expected_lines
@@ -1120,7 +1203,7 @@ def test_print_thread(capsys):
         "pystack.traceback_formatter.format_thread",
         return_value=("1", "2", "3"),
     ):
-        print_thread(thread, native=False)
+        print_thread(thread, native=False, only_last_native_frames=False)
 
     # THEN
 
@@ -1206,7 +1289,7 @@ def test_traceback_formatter_locals(
     with patch("builtins.open", mock_open(read_data=source_data)), patch(
         "os.path.exists", return_value=True
     ):
-        lines = list(format_thread(thread, native=False))
+        lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
     print(lines)
@@ -1244,7 +1327,7 @@ def test_traceback_formatter_thread_names():
 
     # WHEN
 
-    lines = list(format_thread(thread, native=False))
+    lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
     print(lines)
@@ -1305,7 +1388,7 @@ def test_traceback_formatter_position_infomation():
         "pystack.traceback_formatter.colored",
         side_effect=lambda x, *args, **kwargs: x,
     ) as colored_mock:
-        lines = list(format_thread(thread, native=False))
+        lines = list(format_thread(thread, native=False, only_last_native_frames=False))
 
     # THEN
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #142*

**Describe your changes**
Created a new arg called `--native-last`, which shows only C frames after the last printed python frame. This helps to reduce verbose when trying to puzzle out deadlocks and blocking happening in the C code, which the last frames might be enouth.

**Testing performed**
Added `test_traceback_formatter_only_last_native_frames` to ensure that the new mode will show only the last C frames after the last python printed frame.

**Additional context**
Add any other context about your contribution here.