### PR TITLE
Take into account the load point when copying memory from ELF files

### DIFF
--- a/src/pystack/_pystack/elf_common.h
+++ b/src/pystack/_pystack/elf_common.h
@@ -124,6 +124,9 @@ struct SectionInfo
 bool
 getSectionInfo(const std::string& filename, const std::string& section_name, SectionInfo* result);
 
+bool
+getLoadPointOffsetOfElf(const std::string& filename, Dwarf_Addr* result);
+
 std::string
 buildIdPtrToString(const uint8_t* id, ssize_t size);
 

--- a/src/pystack/_pystack/mem.cpp
+++ b/src/pystack/_pystack/mem.cpp
@@ -421,8 +421,18 @@ CorefileRemoteMemoryManager::getMemoryLocationFromElf(
     if (shared_libs_it == d_shared_libs.cend()) {
         return StatusCode::ERROR;
     }
+
+    Dwarf_Addr load_point = 0;
+    auto it = d_load_point_cache.find(shared_libs_it->filename);
+    if (it == d_load_point_cache.end() && getLoadPointOffsetOfElf(shared_libs_it->filename, &load_point)) {
+        d_load_point_cache[shared_libs_it->filename] = load_point;
+        LOG(DEBUG) << "Found load point for copying data from module " << shared_libs_it->filename
+                   << ": " << std::hex << std::showbase << load_point;
+    }
+
     *filename = &shared_libs_it->filename;
-    *offset_in_file = addr - shared_libs_it->start;
+    *offset_in_file = addr - shared_libs_it->start + load_point;
+    LOG(DEBUG) << "Offset in file: " << std::hex << std::showbase << *offset_in_file;
     return StatusCode::SUCCESS;
 }
 

--- a/src/pystack/_pystack/mem.h
+++ b/src/pystack/_pystack/mem.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <unordered_map>
 #include <vector>
 
 #include <elf_common.h>
@@ -213,6 +214,7 @@ class CorefileRemoteMemoryManager : public AbstractRemoteMemoryManager
     std::vector<SimpleVirtualMap> d_shared_libs;
     size_t d_corefile_size;
     std::unique_ptr<char, std::function<void(char*)>> d_corefile_data;
+    mutable std::unordered_map<std::string, Dwarf_Addr> d_load_point_cache;
 
     StatusCode readCorefile(int fd, const char* filename) noexcept;
     StatusCode getMemoryLocationFromCore(remote_addr_t addr, off_t* offset_in_file) const;


### PR DESCRIPTION
When we need to copy memory from ELF files (normally from the static
data section) we need to take into account the load point of the first
PT_LOAD segment to properly map an address to an offset in the file. Our
procedure to do this transformation is to find the first loaded map in
/proc/PID/maps and then calculate the offset of the target address from
the start of this map. This offset only will be the same as the offset
from the start of the ELF file if the load point of the corresponding
PT_LOAD segment is 0, otherwise we need to calculate it to ensure we are
mapping it correctly.

Closes: #174
