### PR TITLE
Harden `--locals` against trashed memory

### DIFF
--- a/news/194.bugfix.rst
+++ b/news/194.bugfix.rst
@@ -1,0 +1,1 @@
+Heap corruption could cause PyStack to fail to generate a stack when ``--locals`` mode was used. This has been fixed by falling back to a reasonable default when attempting to format the repr of a local variable causes a dereference of an invalid pointer.


### PR DESCRIPTION
When attempting to produce a repr for local variables, attempt to cope
better with trashed memory:

- Use "<invalid object at 0x1234>" as the repr of a `PyObject*` pointing
  directly at invalid memory, or one whose `ob_type` points at invalid
  memory.
- Use "<list object at 0x1234>" as, for instance, the repr of a list containing an
  invalid `ob_items` pointer. More generally, use this for any object
  where we can determine the type, but generating the repr according to
  that type's rules fails due to accessing unmapped memory.

Test this with some ctypes abuse.