### PR TITLE
Publish wheels for Python 3.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/---bug-report.yaml
@@ -53,6 +53,7 @@ body:
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13"
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -308,7 +308,6 @@ jobs:
           mv dist/sdist/*.tar.gz dist/
           mv dist/*-wheels/*.whl dist/
           rmdir dist/{sdist,*-wheels}
-          rm -f dist/*cp313*
           ls -R dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ RUN apt-get update \
     python3.12-dev \
     python3.12-dbg \
     python3.12-venv \
+    python3.13-dev \
+    python3.13-dbg \
+    python3.13-venv \
     make \
     cmake \
     gdb \
@@ -93,7 +96,7 @@ ENV PYTHON=python3.12 \
 COPY ["requirements-test.txt", "requirements-extra.txt", "requirements-docs.txt", "/tmp/"]
 
 # Install Python packages
-RUN python3.12 -m venv $VIRTUAL_ENV \
+RUN $PYTHON -m venv $VIRTUAL_ENV \
     && pip install -U pip wheel setuptools cython pkgconfig \
     && pip install -U -r /tmp/requirements-test.txt -r /tmp/requirements-extra.txt
 

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Debuggers",
     ],

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -337,6 +337,8 @@ python_v python_v3_12 = {
         py_cframe<Python3_12::CFrame>(),
 };
 
+// ---- Python 3.13 ------------------------------------------------------------
+
 python_v python_v3_13 = {
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_12::PyCodeObject>(),


### PR DESCRIPTION
Now that Python 3.13 is ABI stable, document that it is supported and begin to publish wheels for it.

We haven't cut a release since we added support for 3.13, so we don't need another news entry. The existing one simply says "Add support for Python 3.13".