### PR TITLE
Add offsets structures for more Python types

### DIFF
--- a/src/pystack/_pystack/cpython/dict.h
+++ b/src/pystack/_pystack/cpython/dict.h
@@ -29,7 +29,7 @@ typedef struct _dictobject
 
 namespace Python3 {
 typedef Py_ssize_t (*dict_lookup_func)(void* mp, PyObject* key, Py_hash_t hash, PyObject** value_addr);
-struct PyDictKeysObject;
+union PyDictKeysObject;
 
 typedef struct
 {
@@ -98,5 +98,15 @@ typedef struct _dictvalues
 } PyDictValuesObject;
 
 }  // namespace Python3_13
+
+typedef union {
+    Python3_3::PyDictKeysObject v3_3;
+    Python3_11::PyDictKeysObject v3_11;
+} PyDictKeysObject;
+
+typedef union {
+    Python3::PyDictValuesObject v3_3;
+    Python3_13::PyDictValuesObject v3_13;
+} PyDictValuesObject;
 
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/string.h
+++ b/src/pystack/_pystack/cpython/string.h
@@ -12,11 +12,13 @@ typedef uint8_t Py_UCS1;
 typedef Py_UCS4 Py_UNICODE;
 typedef Py_ssize_t Py_hash_t;
 
+namespace Python3 {
 typedef struct
 {
     PyObject_VAR_HEAD Py_hash_t ob_shash;
     char ob_sval[1];
 } PyBytesObject;
+}  // namespace Python3
 
 namespace Python2 {
 typedef struct
@@ -106,6 +108,10 @@ typedef struct
 } PyUnicodeObject;
 
 }  // namespace Python3_12
+
+typedef union {
+    Python3::PyBytesObject v3;
+} PyBytesObject;
 
 typedef union {
     Python2::PyUnicodeObject v2;

--- a/src/pystack/_pystack/cpython/string.h
+++ b/src/pystack/_pystack/cpython/string.h
@@ -37,19 +37,21 @@ typedef struct
 
 namespace Python3 {
 
+struct _PyUnicode_State
+{
+    unsigned int interned : 2;
+    unsigned int kind : 3;
+    unsigned int compact : 1;
+    unsigned int ascii : 1;
+    unsigned int ready : 1;
+    unsigned int : 24;
+};
+
 typedef struct
 {
     PyObject_HEAD Py_ssize_t length;
     Py_hash_t hash;
-    struct
-    {
-        unsigned int interned : 2;
-        unsigned int kind : 3;
-        unsigned int compact : 1;
-        unsigned int ascii : 1;
-        unsigned int ready : 1;
-        unsigned int : 24;
-    } state;
+    _PyUnicode_State state;
     wchar_t* wstr;
 } PyASCIIObject;
 
@@ -76,19 +78,13 @@ typedef struct
 
 namespace Python3_12 {
 
+using Python3::_PyUnicode_State;
+
 typedef struct
 {
     PyObject_HEAD Py_ssize_t length;
     Py_hash_t hash;
-    struct
-    {
-        unsigned int interned : 2;
-        unsigned int kind : 3;
-        unsigned int compact : 1;
-        unsigned int ascii : 1;
-        unsigned int ready : 1;
-        unsigned int : 24;
-    } state;
+    _PyUnicode_State state;
 } PyASCIIObject;
 
 typedef struct
@@ -100,6 +96,7 @@ typedef struct
 
 typedef struct
 {
+    PyCompactUnicodeObject _base;
     union {
         void* any;
         Py_UCS1* latin1;

--- a/src/pystack/_pystack/process.cpp
+++ b/src/pystack/_pystack/process.cpp
@@ -471,13 +471,14 @@ AbstractProcessManager::getBytesFromAddress(remote_addr_t addr) const
                    << addr;
         PyBytesObject bytes;
 
-        copyObjectFromProcess(addr, &bytes);
-
-        if ((len = bytes.ob_base.ob_size + 1) < 1) {
-            throw std::runtime_error("Incorrect size of the fetches bytes object");
+        copyMemoryFromProcess(addr, offsets().py_bytes.size, &bytes);
+        len = getField(bytes, &py_bytes_v::o_ob_size) + 1;
+        if (len < 1) {
+            throw std::runtime_error("Incorrect size of the fetched bytes object");
         }
         buffer.resize(len);
-        data_addr = (remote_addr_t)((char*)addr + offsetof(PyBytesObject, ob_sval));
+        data_addr = addr + getFieldOffset(&py_bytes_v::o_ob_sval);
+
         LOG(DEBUG) << std::hex << std::showbase << "Copying data for bytes object from address "
                    << data_addr;
         copyMemoryFromProcess(data_addr, len, buffer.data());

--- a/src/pystack/_pystack/process.cpp
+++ b/src/pystack/_pystack/process.cpp
@@ -677,6 +677,9 @@ AbstractProcessManager::warnIfOffsetsAreMismatched() const
     compare_size(&py_runtime_v::o_dbg_off_type_object_struct_size, py_type);
     compare_offset(&py_runtime_v::o_dbg_off_type_object_tp_name, py_type.o_tp_name);
 
+    compare_size(&py_runtime_v::o_dbg_off_tuple_object_struct_size, py_tuple);
+    compare_offset(&py_runtime_v::o_dbg_off_tuple_object_ob_item, py_tuple.o_ob_item);
+
     compare_size(&py_runtime_v::o_dbg_off_unicode_object_struct_size, py_unicode);
     compare_offset(&py_runtime_v::o_dbg_off_unicode_object_state, py_unicode.o_state);
     compare_offset(&py_runtime_v::o_dbg_off_unicode_object_length, py_unicode.o_length);

--- a/src/pystack/_pystack/process.cpp
+++ b/src/pystack/_pystack/process.cpp
@@ -674,6 +674,9 @@ AbstractProcessManager::warnIfOffsetsAreMismatched() const
     compare_offset(&py_runtime_v::o_dbg_off_code_object_localsplusnames, py_code.o_varnames);
     compare_offset(&py_runtime_v::o_dbg_off_code_object_co_code_adaptive, py_code.o_code_adaptive);
 
+    compare_size(&py_runtime_v::o_dbg_off_pyobject_struct_size, py_object);
+    compare_offset(&py_runtime_v::o_dbg_off_pyobject_ob_type, py_object.o_ob_type);
+
     compare_size(&py_runtime_v::o_dbg_off_type_object_struct_size, py_type);
     compare_offset(&py_runtime_v::o_dbg_off_type_object_tp_name, py_type.o_tp_name);
 

--- a/src/pystack/_pystack/pytypes.cpp
+++ b/src/pystack/_pystack/pytypes.cpp
@@ -121,16 +121,16 @@ ListObject::ListObject(const std::shared_ptr<const AbstractProcessManager>& mana
     d_manager = manager;
 
     PyListObject list;
-    manager->copyObjectFromProcess(addr, &list);
+    manager->copyMemoryFromProcess(addr, manager->offsets().py_list.size, &list);
 
-    ssize_t num_items = list.ob_base.ob_size;
+    ssize_t num_items = manager->getField(list, &py_list_v::o_ob_size);
     if (num_items == 0) {
         LOG(DEBUG) << std::hex << std::showbase << "There are no elements in this list";
         return;
     }
     d_items.resize(num_items);
     manager->copyMemoryFromProcess(
-            (remote_addr_t)list.ob_item,
+            (remote_addr_t)manager->getField(list, &py_list_v::o_ob_item),
             num_items * sizeof(PyObject*),
             d_items.data());
 }

--- a/src/pystack/_pystack/pytypes.cpp
+++ b/src/pystack/_pystack/pytypes.cpp
@@ -89,16 +89,16 @@ TupleObject::TupleObject(
     d_manager = manager;
 
     PyTupleObject tuple;
-    manager->copyObjectFromProcess(addr, &tuple);
+    manager->copyMemoryFromProcess(addr, manager->offsets().py_tuple.size, &tuple);
 
-    ssize_t num_items = tuple.ob_base.ob_size;
+    ssize_t num_items = manager->getField(tuple, &py_tuple_v::o_ob_size);
     if (num_items == 0) {
         LOG(DEBUG) << std::hex << std::showbase << "There are no elements in this tuple";
         return;
     }
     d_items.resize(num_items);
     manager->copyMemoryFromProcess(
-            addr + offsetof(PyTupleObject, ob_item),
+            addr + manager->getFieldOffset(&py_tuple_v::o_ob_item),
             num_items * sizeof(PyObject*),
             d_items.data());
 }

--- a/src/pystack/_pystack/pytypes.cpp
+++ b/src/pystack/_pystack/pytypes.cpp
@@ -636,8 +636,8 @@ double
 Object::toFloat() const
 {
     PyFloatObject the_float;
-    d_manager->copyObjectFromProcess(d_addr, &the_float);
-    return the_float.ob_fval;
+    d_manager->copyMemoryFromProcess(d_addr, d_manager->offsets().py_float.size, &the_float);
+    return d_manager->getField(the_float, &py_float_v::o_ob_fval);
 }
 
 bool

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -331,11 +331,23 @@ py_list()
     };
 }
 
+template<class T>
+constexpr py_long_v
+py_long()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ob_base.ob_size),
+            offsetof(T, ob_digit),
+    };
+}
+
 // ---- Python 2 --------------------------------------------------------------
 
 python_v python_v2 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         {},
         py_object<PyObject>(),
         py_type<Python2::PyTypeObject>(),
@@ -350,6 +362,7 @@ python_v python_v2 = {
 python_v python_v3_3 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -364,6 +377,7 @@ python_v python_v3_3 = {
 python_v python_v3_4 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -378,6 +392,7 @@ python_v python_v3_4 = {
 python_v python_v3_6 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -392,6 +407,7 @@ python_v python_v3_6 = {
 python_v python_v3_7 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -408,6 +424,7 @@ python_v python_v3_7 = {
 python_v python_v3_8 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -424,6 +441,7 @@ python_v python_v3_8 = {
 python_v python_v3_9 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -440,6 +458,7 @@ python_v python_v3_9 = {
 python_v python_v3_10 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -456,6 +475,7 @@ python_v python_v3_10 = {
 python_v python_v3_11 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -473,6 +493,7 @@ python_v python_v3_11 = {
 python_v python_v3_12 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -490,6 +511,7 @@ python_v python_v3_12 = {
 python_v python_v3_13 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_long<_PyLongObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -332,6 +332,53 @@ py_list()
 }
 
 template<class T>
+constexpr py_dict_v
+py_dict()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ma_keys),
+            offsetof(T, ma_values),
+    };
+}
+
+template<class T>
+constexpr py_dictkeys_v
+py_dictkeys()
+{
+    return {
+            sizeof(T),
+            offsetof(T, dk_size),
+            {},
+            offsetof(T, dk_nentries),
+            offsetof(T, dk_indices),
+    };
+}
+
+template<>
+constexpr py_dictkeys_v
+py_dictkeys<Python3_11::PyDictKeysObject>()
+{
+    return {
+            sizeof(Python3_11::PyDictKeysObject),
+            offsetof(Python3_11::PyDictKeysObject, dk_log2_size),
+            offsetof(Python3_11::PyDictKeysObject, dk_kind),
+            offsetof(Python3_11::PyDictKeysObject, dk_nentries),
+            offsetof(Python3_11::PyDictKeysObject, dk_indices),
+    };
+}
+
+template<class T>
+constexpr py_dictvalues_v
+py_dictvalues()
+{
+    return {
+            sizeof(T),
+            offsetof(T, values),
+    };
+}
+
+template<class T>
 constexpr py_float_v
 py_float()
 {
@@ -357,6 +404,9 @@ py_long()
 python_v python_v2 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        {},
+        {},
+        {},
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         {},
@@ -373,6 +423,9 @@ python_v python_v2 = {
 python_v python_v3_3 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -389,6 +442,9 @@ python_v python_v3_3 = {
 python_v python_v3_4 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -405,6 +461,9 @@ python_v python_v3_4 = {
 python_v python_v3_6 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -421,6 +480,9 @@ python_v python_v3_6 = {
 python_v python_v3_7 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -439,6 +501,9 @@ python_v python_v3_7 = {
 python_v python_v3_8 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -457,6 +522,9 @@ python_v python_v3_8 = {
 python_v python_v3_9 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -475,6 +543,9 @@ python_v python_v3_9 = {
 python_v python_v3_10 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_3::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -493,6 +564,9 @@ python_v python_v3_10 = {
 python_v python_v3_11 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_11::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
@@ -512,6 +586,9 @@ python_v python_v3_11 = {
 python_v python_v3_12 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_11::PyDictKeysObject>(),
+        py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
@@ -531,6 +608,9 @@ python_v python_v3_12 = {
 python_v python_v3_13 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_dict<Python3::PyDictObject>(),
+        py_dictkeys<Python3_11::PyDictKeysObject>(),
+        py_dictvalues<Python3_13::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -332,6 +332,16 @@ py_list()
 }
 
 template<class T>
+constexpr py_float_v
+py_float()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ob_fval),
+    };
+}
+
+template<class T>
 constexpr py_long_v
 py_long()
 {
@@ -347,6 +357,7 @@ py_long()
 python_v python_v2 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         {},
         py_object<PyObject>(),
@@ -362,6 +373,7 @@ python_v python_v2 = {
 python_v python_v3_3 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -377,6 +389,7 @@ python_v python_v3_3 = {
 python_v python_v3_4 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -392,6 +405,7 @@ python_v python_v3_4 = {
 python_v python_v3_6 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -407,6 +421,7 @@ python_v python_v3_6 = {
 python_v python_v3_7 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -424,6 +439,7 @@ python_v python_v3_7 = {
 python_v python_v3_8 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -441,6 +457,7 @@ python_v python_v3_8 = {
 python_v python_v3_9 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -458,6 +475,7 @@ python_v python_v3_9 = {
 python_v python_v3_10 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -475,6 +493,7 @@ python_v python_v3_10 = {
 python_v python_v3_11 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -493,6 +512,7 @@ python_v python_v3_11 = {
 python_v python_v3_12 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_object<PyObject>(),
@@ -511,6 +531,7 @@ python_v python_v3_12 = {
 python_v python_v3_13 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
+        py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_object<PyObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -298,6 +298,17 @@ py_object()
 }
 
 template<class T>
+constexpr py_bytes_v
+py_bytes()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ob_base.ob_size),
+            offsetof(T, ob_sval),
+    };
+}
+
+template<class T>
 constexpr py_unicode_v
 py_unicode()
 {
@@ -410,6 +421,7 @@ python_v python_v2 = {
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
         {},
+        {},
         py_object<PyObject>(),
         py_type<Python2::PyTypeObject>(),
         py_code<Python2::PyCodeObject>(),
@@ -428,6 +440,7 @@ python_v python_v3_3 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -447,6 +460,7 @@ python_v python_v3_4 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -466,6 +480,7 @@ python_v python_v3_6 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -485,6 +500,7 @@ python_v python_v3_7 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
@@ -506,6 +522,7 @@ python_v python_v3_8 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -527,6 +544,7 @@ python_v python_v3_9 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -548,6 +566,7 @@ python_v python_v3_10 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -569,6 +588,7 @@ python_v python_v3_11 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -591,6 +611,7 @@ python_v python_v3_12 = {
         py_dictvalues<Python3::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
@@ -613,6 +634,7 @@ python_v python_v3_13 = {
         py_dictvalues<Python3_13::PyDictValuesObject>(),
         py_float<PyFloatObject>(),
         py_long<_PyLongObject>(),
+        py_bytes<Python3::PyBytesObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -288,6 +288,16 @@ py_type()
 }
 
 template<class T>
+constexpr py_object_v
+py_object()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ob_type),
+    };
+}
+
+template<class T>
 constexpr py_unicode_v
 py_unicode()
 {
@@ -327,6 +337,7 @@ python_v python_v2 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         {},
+        py_object<PyObject>(),
         py_type<Python2::PyTypeObject>(),
         py_code<Python2::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -340,6 +351,7 @@ python_v python_v3_3 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -353,6 +365,7 @@ python_v python_v3_4 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -366,6 +379,7 @@ python_v python_v3_6 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -379,6 +393,7 @@ python_v python_v3_7 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
         py_frame<Python3_7::PyFrameObject>(),
@@ -394,6 +409,7 @@ python_v python_v3_8 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
         py_frame<Python3_7::PyFrameObject>(),
@@ -409,6 +425,7 @@ python_v python_v3_9 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
         py_frame<Python3_7::PyFrameObject>(),
@@ -424,6 +441,7 @@ python_v python_v3_10 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
         py_frame<Python3_10::PyFrameObject>(),
@@ -439,6 +457,7 @@ python_v python_v3_11 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_11::PyCodeObject>(),
         py_framev311<Python3_11::PyFrameObject>(),
@@ -455,6 +474,7 @@ python_v python_v3_12 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_12::PyCodeObject>(),
         py_framev312<Python3_12::PyFrameObject>(),
@@ -471,6 +491,7 @@ python_v python_v3_13 = {
         py_tuple<PyTupleObject>(),
         py_list<PyListObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
+        py_object<PyObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_13::PyCodeObject>(),
         py_framev312<Python3_12::PyFrameObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -310,10 +310,22 @@ py_tuple()
     };
 }
 
+template<class T>
+constexpr py_list_v
+py_list()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ob_base.ob_size),
+            offsetof(T, ob_item),
+    };
+}
+
 // ---- Python 2 --------------------------------------------------------------
 
 python_v python_v2 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         {},
         py_type<Python2::PyTypeObject>(),
         py_code<Python2::PyCodeObject>(),
@@ -326,6 +338,7 @@ python_v python_v2 = {
 
 python_v python_v3_3 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
@@ -338,6 +351,7 @@ python_v python_v3_3 = {
 
 python_v python_v3_4 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
@@ -350,6 +364,7 @@ python_v python_v3_4 = {
 
 python_v python_v3_6 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
@@ -362,6 +377,7 @@ python_v python_v3_6 = {
 
 python_v python_v3_7 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
@@ -376,6 +392,7 @@ python_v python_v3_7 = {
 
 python_v python_v3_8 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
@@ -390,6 +407,7 @@ python_v python_v3_8 = {
 
 python_v python_v3_9 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
@@ -404,6 +422,7 @@ python_v python_v3_9 = {
 
 python_v python_v3_10 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
@@ -418,6 +437,7 @@ python_v python_v3_10 = {
 
 python_v python_v3_11 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_11::PyCodeObject>(),
@@ -433,6 +453,7 @@ python_v python_v3_11 = {
 
 python_v python_v3_12 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_12::PyCodeObject>(),
@@ -448,6 +469,7 @@ python_v python_v3_12 = {
 
 python_v python_v3_13 = {
         py_tuple<PyTupleObject>(),
+        py_list<PyListObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_13::PyCodeObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -269,6 +269,10 @@ py_runtimev313()
             offsetof(T, debug_offsets.pyobject.ob_type),
             offsetof(T, debug_offsets.type_object.size),
             offsetof(T, debug_offsets.type_object.tp_name),
+            offsetof(T, debug_offsets.unicode_object.size),
+            offsetof(T, debug_offsets.unicode_object.state),
+            offsetof(T, debug_offsets.unicode_object.length),
+            offsetof(T, debug_offsets.unicode_object.asciiobject_size),
             offsetof(T, debug_offsets.gc.size),
             offsetof(T, debug_offsets.gc.collecting),
     };
@@ -281,9 +285,22 @@ py_type()
     return {sizeof(T), offsetof(T, tp_name), offsetof(T, tp_repr), offsetof(T, tp_flags)};
 }
 
+template<class T>
+constexpr py_unicode_v
+py_unicode()
+{
+    return {
+            sizeof(T),
+            offsetof(T, _base._base.state),
+            offsetof(T, _base._base.length),
+            offsetof(T, _base) + sizeof(T::_base._base),
+    };
+}
+
 // ---- Python 2 --------------------------------------------------------------
 
 python_v python_v2 = {
+        {},
         py_type<Python2::PyTypeObject>(),
         py_code<Python2::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -294,6 +311,7 @@ python_v python_v2 = {
 // ---- Python 3.3 ------------------------------------------------------------
 
 python_v python_v3_3 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -304,6 +322,7 @@ python_v python_v3_3 = {
 // ---- Python 3.4 ------------------------------------------------------------
 
 python_v python_v3_4 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -314,6 +333,7 @@ python_v python_v3_4 = {
 // ---- Python 3.6 ------------------------------------------------------------
 
 python_v python_v3_6 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
         py_frame<Python2::PyFrameObject>(),
@@ -324,6 +344,7 @@ python_v python_v3_6 = {
 // ---- Python 3.7 ------------------------------------------------------------
 
 python_v python_v3_7 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
         py_frame<Python3_7::PyFrameObject>(),
@@ -336,6 +357,7 @@ python_v python_v3_7 = {
 // ---- Python 3.8 ------------------------------------------------------------
 
 python_v python_v3_8 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
         py_frame<Python3_7::PyFrameObject>(),
@@ -348,6 +370,7 @@ python_v python_v3_8 = {
 // ---- Python 3.9 ------------------------------------------------------------
 
 python_v python_v3_9 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
         py_frame<Python3_7::PyFrameObject>(),
@@ -360,6 +383,7 @@ python_v python_v3_9 = {
 // ---- Python 3.10 ------------------------------------------------------------
 
 python_v python_v3_10 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
         py_frame<Python3_10::PyFrameObject>(),
@@ -372,6 +396,7 @@ python_v python_v3_10 = {
 // ---- Python 3.11 ------------------------------------------------------------
 
 python_v python_v3_11 = {
+        py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_11::PyCodeObject>(),
         py_framev311<Python3_11::PyFrameObject>(),
@@ -385,6 +410,7 @@ python_v python_v3_11 = {
 // ---- Python 3.12 ------------------------------------------------------------
 
 python_v python_v3_12 = {
+        py_unicode<Python3_12::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_12::PyCodeObject>(),
         py_framev312<Python3_12::PyFrameObject>(),
@@ -398,6 +424,7 @@ python_v python_v3_12 = {
 // ---- Python 3.13 ------------------------------------------------------------
 
 python_v python_v3_13 = {
+        py_unicode<Python3_12::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_13::PyCodeObject>(),
         py_framev312<Python3_12::PyFrameObject>(),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -269,6 +269,8 @@ py_runtimev313()
             offsetof(T, debug_offsets.pyobject.ob_type),
             offsetof(T, debug_offsets.type_object.size),
             offsetof(T, debug_offsets.type_object.tp_name),
+            offsetof(T, debug_offsets.tuple_object.size),
+            offsetof(T, debug_offsets.tuple_object.ob_item),
             offsetof(T, debug_offsets.unicode_object.size),
             offsetof(T, debug_offsets.unicode_object.state),
             offsetof(T, debug_offsets.unicode_object.length),
@@ -297,9 +299,21 @@ py_unicode()
     };
 }
 
+template<class T>
+constexpr py_tuple_v
+py_tuple()
+{
+    return {
+            sizeof(T),
+            offsetof(T, ob_base.ob_size),
+            offsetof(T, ob_item),
+    };
+}
+
 // ---- Python 2 --------------------------------------------------------------
 
 python_v python_v2 = {
+        py_tuple<PyTupleObject>(),
         {},
         py_type<Python2::PyTypeObject>(),
         py_code<Python2::PyCodeObject>(),
@@ -311,6 +325,7 @@ python_v python_v2 = {
 // ---- Python 3.3 ------------------------------------------------------------
 
 python_v python_v3_3 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
@@ -322,6 +337,7 @@ python_v python_v3_3 = {
 // ---- Python 3.4 ------------------------------------------------------------
 
 python_v python_v3_4 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_3::PyCodeObject>(),
@@ -333,6 +349,7 @@ python_v python_v3_4 = {
 // ---- Python 3.6 ------------------------------------------------------------
 
 python_v python_v3_6 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
@@ -344,6 +361,7 @@ python_v python_v3_6 = {
 // ---- Python 3.7 ------------------------------------------------------------
 
 python_v python_v3_7 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_3::PyTypeObject>(),
         py_code<Python3_6::PyCodeObject>(),
@@ -357,6 +375,7 @@ python_v python_v3_7 = {
 // ---- Python 3.8 ------------------------------------------------------------
 
 python_v python_v3_8 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
@@ -370,6 +389,7 @@ python_v python_v3_8 = {
 // ---- Python 3.9 ------------------------------------------------------------
 
 python_v python_v3_9 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
@@ -383,6 +403,7 @@ python_v python_v3_9 = {
 // ---- Python 3.10 ------------------------------------------------------------
 
 python_v python_v3_10 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_code<Python3_8::PyCodeObject>(),
@@ -396,6 +417,7 @@ python_v python_v3_10 = {
 // ---- Python 3.11 ------------------------------------------------------------
 
 python_v python_v3_11 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_11::PyCodeObject>(),
@@ -410,6 +432,7 @@ python_v python_v3_11 = {
 // ---- Python 3.12 ------------------------------------------------------------
 
 python_v python_v3_12 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_12::PyCodeObject>(),
@@ -424,6 +447,7 @@ python_v python_v3_12 = {
 // ---- Python 3.13 ------------------------------------------------------------
 
 python_v python_v3_13 = {
+        py_tuple<PyTupleObject>(),
         py_unicode<Python3_12::PyUnicodeObject>(),
         py_type<Python3_8::PyTypeObject>(),
         py_codev311<Python3_13::PyCodeObject>(),

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -34,6 +34,31 @@ struct py_list_v
     FieldOffset<PyObject**> o_ob_item;
 };
 
+struct py_dict_v
+{
+    typedef Python3::PyDictObject Structure;
+    ssize_t size;
+    FieldOffset<remote_addr_t> o_ma_keys;
+    FieldOffset<remote_addr_t> o_ma_values;
+};
+
+struct py_dictkeys_v
+{
+    typedef PyDictKeysObject Structure;
+    ssize_t size;
+    FieldOffset<Py_ssize_t> o_dk_size;
+    FieldOffset<uint8_t> o_dk_kind;
+    FieldOffset<Py_ssize_t> o_dk_nentries;
+    FieldOffset<char[1]> o_dk_indices;
+};
+
+struct py_dictvalues_v
+{
+    typedef PyDictValuesObject Structure;
+    ssize_t size;
+    FieldOffset<remote_addr_t[1]> o_values;
+};
+
 struct py_float_v
 {
     typedef PyFloatObject Structure;
@@ -214,6 +239,9 @@ struct python_v
 {
     py_tuple_v py_tuple;
     py_list_v py_list;
+    py_dict_v py_dict;
+    py_dictkeys_v py_dictkeys;
+    py_dictvalues_v py_dictvalues;
     py_float_v py_float;
     py_long_v py_long;
     py_unicode_v py_unicode;
@@ -240,6 +268,9 @@ struct python_v
 
 define_python_v_get_specialization(py_tuple);
 define_python_v_get_specialization(py_list);
+define_python_v_get_specialization(py_dict);
+define_python_v_get_specialization(py_dictkeys);
+define_python_v_get_specialization(py_dictvalues);
 define_python_v_get_specialization(py_float);
 define_python_v_get_specialization(py_long);
 define_python_v_get_specialization(py_unicode);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -74,6 +74,14 @@ struct py_long_v
     FieldOffset<digit[1]> o_ob_digit;
 };
 
+struct py_bytes_v
+{
+    typedef PyBytesObject Structure;
+    ssize_t size;
+    FieldOffset<Py_ssize_t> o_ob_size;
+    FieldOffset<char[1]> o_ob_sval;
+};
+
 struct py_unicode_v
 {
     typedef PyUnicodeObject Structure;
@@ -244,6 +252,7 @@ struct python_v
     py_dictvalues_v py_dictvalues;
     py_float_v py_float;
     py_long_v py_long;
+    py_bytes_v py_bytes;
     py_unicode_v py_unicode;
     py_object_v py_object;
     py_type_v py_type;
@@ -273,6 +282,7 @@ define_python_v_get_specialization(py_dictkeys);
 define_python_v_get_specialization(py_dictvalues);
 define_python_v_get_specialization(py_float);
 define_python_v_get_specialization(py_long);
+define_python_v_get_specialization(py_bytes);
 define_python_v_get_specialization(py_unicode);
 define_python_v_get_specialization(py_object);
 define_python_v_get_specialization(py_type);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -34,6 +34,14 @@ struct py_list_v
     FieldOffset<PyObject**> o_ob_item;
 };
 
+struct py_long_v
+{
+    typedef _PyLongObject Structure;
+    ssize_t size;
+    FieldOffset<Py_ssize_t> o_ob_size;
+    FieldOffset<digit[1]> o_ob_digit;
+};
+
 struct py_unicode_v
 {
     typedef PyUnicodeObject Structure;
@@ -199,6 +207,7 @@ struct python_v
 {
     py_tuple_v py_tuple;
     py_list_v py_list;
+    py_long_v py_long;
     py_unicode_v py_unicode;
     py_object_v py_object;
     py_type_v py_type;
@@ -223,6 +232,7 @@ struct python_v
 
 define_python_v_get_specialization(py_tuple);
 define_python_v_get_specialization(py_list);
+define_python_v_get_specialization(py_long);
 define_python_v_get_specialization(py_unicode);
 define_python_v_get_specialization(py_object);
 define_python_v_get_specialization(py_type);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -43,6 +43,13 @@ struct py_unicode_v
     FieldOffset<remote_addr_t> o_ascii;
 };
 
+struct py_object_v
+{
+    typedef PyObject Structure;
+    ssize_t size;
+    FieldOffset<remote_addr_t> o_ob_type;
+};
+
 struct py_code_v
 {
     typedef PyCodeObject Structure;
@@ -193,6 +200,7 @@ struct python_v
     py_tuple_v py_tuple;
     py_list_v py_list;
     py_unicode_v py_unicode;
+    py_object_v py_object;
     py_type_v py_type;
     py_code_v py_code;
     py_frame_v py_frame;
@@ -216,6 +224,7 @@ struct python_v
 define_python_v_get_specialization(py_tuple);
 define_python_v_get_specialization(py_list);
 define_python_v_get_specialization(py_unicode);
+define_python_v_get_specialization(py_object);
 define_python_v_get_specialization(py_type);
 define_python_v_get_specialization(py_code);
 define_python_v_get_specialization(py_frame);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -18,6 +18,14 @@ struct FieldOffset
     offset_t offset;
 };
 
+struct py_tuple_v
+{
+    typedef PyTupleObject Structure;
+    ssize_t size;
+    FieldOffset<Py_ssize_t> o_ob_size;
+    FieldOffset<PyObject* [1]> o_ob_item;
+};
+
 struct py_unicode_v
 {
     typedef PyUnicodeObject Structure;
@@ -124,6 +132,9 @@ struct py_runtime_v
     FieldOffset<uint64_t> o_dbg_off_type_object_struct_size;
     FieldOffset<uint64_t> o_dbg_off_type_object_tp_name;
 
+    FieldOffset<uint64_t> o_dbg_off_tuple_object_struct_size;
+    FieldOffset<uint64_t> o_dbg_off_tuple_object_ob_item;
+
     FieldOffset<uint64_t> o_dbg_off_unicode_object_struct_size;
     FieldOffset<uint64_t> o_dbg_off_unicode_object_state;
     FieldOffset<uint64_t> o_dbg_off_unicode_object_length;
@@ -171,6 +182,7 @@ struct py_cframe_v
 
 struct python_v
 {
+    py_tuple_v py_tuple;
     py_unicode_v py_unicode;
     py_type_v py_type;
     py_code_v py_code;
@@ -192,6 +204,7 @@ struct python_v
         return T;                                                                                       \
     }
 
+define_python_v_get_specialization(py_tuple);
 define_python_v_get_specialization(py_unicode);
 define_python_v_get_specialization(py_type);
 define_python_v_get_specialization(py_code);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -18,6 +18,15 @@ struct FieldOffset
     offset_t offset;
 };
 
+struct py_unicode_v
+{
+    typedef PyUnicodeObject Structure;
+    ssize_t size;
+    FieldOffset<Python3::_PyUnicode_State> o_state;
+    FieldOffset<Py_ssize_t> o_length;
+    FieldOffset<remote_addr_t> o_ascii;
+};
+
 struct py_code_v
 {
     typedef PyCodeObject Structure;
@@ -115,6 +124,11 @@ struct py_runtime_v
     FieldOffset<uint64_t> o_dbg_off_type_object_struct_size;
     FieldOffset<uint64_t> o_dbg_off_type_object_tp_name;
 
+    FieldOffset<uint64_t> o_dbg_off_unicode_object_struct_size;
+    FieldOffset<uint64_t> o_dbg_off_unicode_object_state;
+    FieldOffset<uint64_t> o_dbg_off_unicode_object_length;
+    FieldOffset<size_t> o_dbg_off_unicode_object_asciiobject_size;
+
     FieldOffset<uint64_t> o_dbg_off_gc_struct_size;
     FieldOffset<uint64_t> o_dbg_off_gc_collecting;
 };
@@ -157,6 +171,7 @@ struct py_cframe_v
 
 struct python_v
 {
+    py_unicode_v py_unicode;
     py_type_v py_type;
     py_code_v py_code;
     py_frame_v py_frame;
@@ -177,6 +192,7 @@ struct python_v
         return T;                                                                                       \
     }
 
+define_python_v_get_specialization(py_unicode);
 define_python_v_get_specialization(py_type);
 define_python_v_get_specialization(py_code);
 define_python_v_get_specialization(py_frame);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -26,6 +26,14 @@ struct py_tuple_v
     FieldOffset<PyObject* [1]> o_ob_item;
 };
 
+struct py_list_v
+{
+    typedef PyListObject Structure;
+    ssize_t size;
+    FieldOffset<Py_ssize_t> o_ob_size;
+    FieldOffset<PyObject**> o_ob_item;
+};
+
 struct py_unicode_v
 {
     typedef PyUnicodeObject Structure;
@@ -183,6 +191,7 @@ struct py_cframe_v
 struct python_v
 {
     py_tuple_v py_tuple;
+    py_list_v py_list;
     py_unicode_v py_unicode;
     py_type_v py_type;
     py_code_v py_code;
@@ -205,6 +214,7 @@ struct python_v
     }
 
 define_python_v_get_specialization(py_tuple);
+define_python_v_get_specialization(py_list);
 define_python_v_get_specialization(py_unicode);
 define_python_v_get_specialization(py_type);
 define_python_v_get_specialization(py_code);

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -34,6 +34,13 @@ struct py_list_v
     FieldOffset<PyObject**> o_ob_item;
 };
 
+struct py_float_v
+{
+    typedef PyFloatObject Structure;
+    ssize_t size;
+    FieldOffset<double> o_ob_fval;
+};
+
 struct py_long_v
 {
     typedef _PyLongObject Structure;
@@ -207,6 +214,7 @@ struct python_v
 {
     py_tuple_v py_tuple;
     py_list_v py_list;
+    py_float_v py_float;
     py_long_v py_long;
     py_unicode_v py_unicode;
     py_object_v py_object;
@@ -232,6 +240,7 @@ struct python_v
 
 define_python_v_get_specialization(py_tuple);
 define_python_v_get_specialization(py_list);
+define_python_v_get_specialization(py_float);
 define_python_v_get_specialization(py_long);
 define_python_v_get_specialization(py_unicode);
 define_python_v_get_specialization(py_object);


### PR DESCRIPTION
Up until now we've been using our `python_v` structs for the interpreter state, but not for Python objects. This has led us to bake deep seated assumptions into our code (like that the size of `PyObject` is and will always be `2*sizeof(void*)`), and led us to mix code for handling interpretation of an object from its fields with code for handling changes to the offsets of those fields, making our implementations less maintainable.

Fix both issues by adding the Python types that we care about for `--locals` to `python_v`.

This also paves the way for us to use Python 3.13+'s Py_DebugOffsets structure for decoding Python objects.