### PR TITLE
Fix compiler errors and some error paths

### DIFF
--- a/src/pystack/_pystack/corefile.cpp
+++ b/src/pystack/_pystack/corefile.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <fstream>

--- a/src/pystack/_pystack/mem.cpp
+++ b/src/pystack/_pystack/mem.cpp
@@ -368,7 +368,7 @@ CorefileRemoteMemoryManager::copyMemoryFromProcess(remote_addr_t addr, size_t si
     StatusCode ret = getMemoryLocationFromCore(addr, &offset_in_file);
 
     if (ret == StatusCode::SUCCESS) {
-        if (static_cast<size_t>(offset_in_file) > d_corefile_size) {
+        if (size > d_corefile_size || static_cast<size_t>(offset_in_file) > d_corefile_size - size) {
             throw InvalidRemoteAddress();
         }
         memcpy(destination, d_corefile_data.get() + offset_in_file, size);

--- a/src/pystack/_pystack/process.cpp
+++ b/src/pystack/_pystack/process.cpp
@@ -584,7 +584,12 @@ AbstractProcessManager::findPythonVersion() const
         return {-1, -1};
     }
     unsigned long version;
-    copyObjectFromProcess(version_symbol, &version);
+    try {
+        copyObjectFromProcess(version_symbol, &version);
+    } catch (RemoteMemCopyError& ex) {
+        LOG(DEBUG) << "Failed to determine Python version from symbols";
+        return {-1, -1};
+    }
     int major = (version >> 24) & 0xFF;
     int minor = (version >> 16) & 0xFF;
     LOG(DEBUG) << "Python version determined from symbols: " << major << "." << minor;

--- a/src/pystack/_pystack/pycode.cpp
+++ b/src/pystack/_pystack/pycode.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <stdexcept>
 #include <vector>

--- a/src/pystack/_pystack/unwinder.cpp
+++ b/src/pystack/_pystack/unwinder.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <cxxabi.h>


### PR DESCRIPTION
When compiling pystack with gcc 14, the C++ standard library headers are
not giving us transitevely the 'algorithm' include and we are missing it
explicitly so it currently fails to compile.

Additionally, we are not properly handling some of the exceptions that
are being raised when something fails when copying memory when we are
resolving the Python version.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
