### PR TITLE
Add a --version command line flag to show the version

### DIFF
--- a/news/203.feature.rst
+++ b/news/203.feature.rst
@@ -1,0 +1,1 @@
+Add a new ``--version`` command line flag to show the version of pystack

--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -12,6 +12,7 @@ from typing import NoReturn
 from typing import Optional
 from typing import Set
 
+from pystack import __version__
 from pystack.errors import InvalidPythonProcess
 from pystack.process import decompress_gzip
 from pystack.process import is_elf
@@ -117,6 +118,9 @@ def generate_cli_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "-v", "--verbose", action="count", default=0, dest="global_verbose"
+    )
+    parser.add_argument(
+        "--version", action="version", version=__version__, help="Show version"
     )
     parser.add_argument(
         "--no-color",


### PR DESCRIPTION
This will help users report the version of pystack when creating bug more easily.

Closes: https://github.com/bloomberg/pystack/issues/200
