### PR TITLE
Protect against shim frames at the bottom of the stack

### DIFF
--- a/news/204.bugfix.rst
+++ b/news/204.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash when analysing processes where the eval loop has a shim frame at the bottom of the stack

--- a/src/pystack/_pystack/pyframe.h
+++ b/src/pystack/_pystack/pyframe.h
@@ -25,6 +25,7 @@ class FrameObject
     const std::unordered_map<std::string, std::string>& Arguments() const;
     const std::unordered_map<std::string, std::string>& Locals() const;
     bool IsEntryFrame() const;
+    bool IsShim() const;
 
     // Methods
     void resolveLocalVariables();
@@ -37,10 +38,8 @@ class FrameObject
     static std::unique_ptr<CodeObject>
     getCode(const std::shared_ptr<const AbstractProcessManager>& manager, const PyFrameObject& frame);
 
-    static std::pair<std::shared_ptr<FrameObject>, bool> getPrevAndIsEntry(
-            const std::shared_ptr<const AbstractProcessManager>& manager,
-            const PyFrameObject& frame,
-            ssize_t frame_no);
+    bool
+    isEntry(const std::shared_ptr<const AbstractProcessManager>& manager, const PyFrameObject& frame);
 
     // Data members
     const std::shared_ptr<const AbstractProcessManager> d_manager{};

--- a/src/pystack/_pystack/pyframe.pxd
+++ b/src/pystack/_pystack/pyframe.pxd
@@ -14,5 +14,6 @@ cdef extern from "pyframe.h" namespace "pystack":
         unordered_map[cppstring, cppstring] Arguments()
         unordered_map[cppstring, cppstring] Locals()
         bool IsEntryFrame()
+        bool IsShim()
 
         void resolveLocalVariables() except+

--- a/src/pystack/types.py
+++ b/src/pystack/types.py
@@ -97,6 +97,7 @@ class PyFrame:
     arguments: Dict[str, str]
     locals: Dict[str, str]
     is_entry: bool
+    is_shim: bool
 
 
 @dataclass
@@ -111,6 +112,14 @@ class PyThread:
 
     @property
     def frames(self) -> Iterable[PyFrame]:
+        yield from filter(lambda frame: not frame.is_shim, self.all_frames)
+
+    @property
+    def first_frame(self) -> Optional[PyFrame]:
+        return next(iter(self.frames), None)
+
+    @property
+    def all_frames(self) -> Iterable[PyFrame]:
         current_frame = self.frame
         while current_frame is not None:
             yield current_frame

--- a/tests/integration/shim_deallocation_program.py
+++ b/tests/integration/shim_deallocation_program.py
@@ -1,0 +1,14 @@
+import asyncio
+import os
+
+
+class AbortInDunderDel:
+    __del__ = os.abort
+
+
+async def main():
+    f = asyncio.Future()
+    f.set_result(AbortInDunderDel())
+
+
+asyncio.run(main())

--- a/tests/integration/test_gather_stacks.py
+++ b/tests/integration/test_gather_stacks.py
@@ -126,7 +126,9 @@ def test_multiple_thread_stack(python, blocking, method, tmpdir):
 
     assert len(threads) == 4
     main_thread = [
-        thread for thread in threads if "threading" not in thread.frame.code.filename
+        thread
+        for thread in threads
+        if "threading" not in thread.first_frame.code.filename
     ][0]
     other_threads = [thread for thread in threads if thread != main_thread]
 
@@ -245,7 +247,9 @@ def test_multiple_thread_stack_native(python, method, blocking, tmpdir):
 
     assert len(threads) == 4
     main_thread = [
-        thread for thread in threads if "threading" not in thread.frame.code.filename
+        thread
+        for thread in threads
+        if "threading" not in thread.first_frame.code.filename
     ][0]
     other_threads = [thread for thread in threads if thread != main_thread]
 


### PR DESCRIPTION
It's possible that pystack analyses a core file or a program at a
specific moment where the bottom of the stack has a shim frame but a
normal frame has not been pushed yet or the last normal frame has been
removed because the evaluation loop is returning.

In this case, we were not resolving the code object, but we are not
skipping the frame either because it's the first frame. This was causing
the code object pointer in the frame to be NULL but we are not checking
for that condition when unwinding.

Closes: #199