### PR TITLE
Use _Py_DebugOffsets instead of hardcoded offsets when possible

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -152,6 +152,49 @@ jobs:
           PYTHON_TEST_VERSION: "auto"
         run: python${{matrix.python_version}} -m pytest tests -k 'not 2.7' -n auto -vvv
 
+  test_free_threading:
+    needs: [build_wheels]
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{matrix.python_version}}-dev"
+      - uses: actions/download-artifact@v4
+        with:
+          name: "manylinux_x86_64-wheels"
+          path: dist
+      - name: Set up dependencies
+        run: |
+          sudo add-apt-repository ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -qy \
+            gdb \
+            python${{matrix.python_version}}-dev \
+            python${{matrix.python_version}}-nogil \
+            python${{matrix.python_version}}-venv
+      - name: Install Python dependencies
+        run: |
+          python${{matrix.python_version}} -m pip install --upgrade pip
+          python${{matrix.python_version}} -m pip install -r requirements-test.txt
+          python${{matrix.python_version}} -m pip install --no-index --find-links=dist/ --only-binary=pystack pystack
+      - name: Install setuptools for the free-threading version
+        run: |
+          python${{matrix.python_version}}t -m venv --system-site-packages /tmp/pip${{matrix.python_version}}
+          /tmp/pip${{matrix.python_version}}/bin/pip install --user setuptools
+      - name: Disable ptrace security restrictions
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+      - name: Run pytest
+        env:
+          PYTHON_TEST_VERSION: "${{matrix.python_version}}t"
+        run: python${{matrix.python_version}} -m pytest tests -k 'not 2.7' -n auto -vvv
+
   test_in_alpine:
     needs: [build_wheels]
     runs-on: ubuntu-latest

--- a/news/206.feature.rst
+++ b/news/206.feature.rst
@@ -1,0 +1,1 @@
+Support debugging free-threading (a.k.a. "nogil") Python 3.13 builds. Note that PyStack can't itself be run with ``python3.13t``, it can only attach to a ``python3.13t`` process or core file from another interpreter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,8 @@ omit = [
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.pytest.ini_options]
+# pytest retains all temp files from the last 3 test suite runs by default.
+# Keep only ones for failed tests to avoid filling up a disk.
+tmp_path_retention_policy = "failed"

--- a/src/pystack/_pystack.pyi
+++ b/src/pystack/_pystack.pyi
@@ -36,6 +36,7 @@ class StackMethod(enum.Enum):
     ELF_DATA: int
     HEAP: int
     SYMBOLS: int
+    DEBUG_OFFSETS: int
 
 class ProcessManager: ...
 

--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -307,6 +307,7 @@ cdef class ProcessManager:
             )
         )
 
+        native_manager.get().setPythonVersionFromDebugOffsets()
         python_version = native_manager.get().findPythonVersion()
         if python_version == (-1, -1):
             python_version = get_python_version_for_process(pid, map_info)
@@ -353,10 +354,12 @@ cdef class ProcessManager:
             make_shared[CoreFileProcessManager](pid, analyzer, maps, native_map_info)
         )
 
+        native_manager.get().setPythonVersionFromDebugOffsets()
         python_version = native_manager.get().findPythonVersion()
         if python_version == (-1, -1):
             python_version = get_python_version_for_core(core_file, executable, map_info)
         native_manager.get().setPythonVersion(python_version)
+
         cdef ProcessManager new_manager = cls(
             pid, python_version, virtual_maps, map_info
         )

--- a/src/pystack/_pystack.pyx
+++ b/src/pystack/_pystack.pyx
@@ -77,7 +77,8 @@ class StackMethod(enum.Enum):
     BSS = 1 << 2
     ANONYMOUS_MAPS = 1 << 3
     HEAP = 1 << 4
-    AUTO = ELF_DATA | SYMBOLS | BSS
+    DEBUG_OFFSETS = 1 << 5
+    AUTO = DEBUG_OFFSETS | ELF_DATA | SYMBOLS | BSS
     ALL = AUTO | ANONYMOUS_MAPS | HEAP
 
 
@@ -530,6 +531,7 @@ cdef remote_addr_t _get_interpreter_state_addr(
 ) except*:
     cdef remote_addr_t head = 0
     possible_methods = [
+        StackMethod.DEBUG_OFFSETS,
         StackMethod.ELF_DATA,
         StackMethod.SYMBOLS,
         StackMethod.BSS,
@@ -542,7 +544,10 @@ cdef remote_addr_t _get_interpreter_state_addr(
             continue
 
         try:
-            if possible_method == StackMethod.ELF_DATA:
+            if possible_method == StackMethod.DEBUG_OFFSETS:
+                how = "using debug offsets data"
+                head = manager.findInterpreterStateFromDebugOffsets()
+            elif possible_method == StackMethod.ELF_DATA:
                 how = "using ELF data"
                 head = manager.findInterpreterStateFromElfData()
             elif possible_method == StackMethod.SYMBOLS:

--- a/src/pystack/_pystack/cpython/code.h
+++ b/src/pystack/_pystack/cpython/code.h
@@ -197,14 +197,4 @@ typedef struct
 } PyCodeObject;
 }  // namespace Python3_13
 
-typedef union {
-    Python2::PyCodeObject v2;
-    Python3_3::PyCodeObject v3_3;
-    Python3_6::PyCodeObject v3_6;
-    Python3_8::PyCodeObject v3_8;
-    Python3_11::PyCodeObject v3_11;
-    Python3_12::PyCodeObject v3_12;
-    Python3_13::PyCodeObject v3_13;
-} PyCodeObject;
-
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/dict.h
+++ b/src/pystack/_pystack/cpython/dict.h
@@ -29,7 +29,7 @@ typedef struct _dictobject
 
 namespace Python3 {
 typedef Py_ssize_t (*dict_lookup_func)(void* mp, PyObject* key, Py_hash_t hash, PyObject** value_addr);
-union PyDictKeysObject;
+struct PyDictKeysObject;
 
 typedef struct
 {
@@ -98,15 +98,5 @@ typedef struct _dictvalues
 } PyDictValuesObject;
 
 }  // namespace Python3_13
-
-typedef union {
-    Python3_3::PyDictKeysObject v3_3;
-    Python3_11::PyDictKeysObject v3_11;
-} PyDictKeysObject;
-
-typedef union {
-    Python3::PyDictValuesObject v3_3;
-    Python3_13::PyDictValuesObject v3_13;
-} PyDictValuesObject;
 
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/dict.h
+++ b/src/pystack/_pystack/cpython/dict.h
@@ -82,7 +82,7 @@ typedef struct _dictkeysobject
     uint32_t dk_version;
     Py_ssize_t dk_usable;
     Py_ssize_t dk_nentries;
-    char dk_indices[]; /* char is required to avoid strict aliasing. */
+    char dk_indices[1]; /* char is required to avoid strict aliasing. */
 } PyDictKeysObject;
 }  // namespace Python3_11
 

--- a/src/pystack/_pystack/cpython/frame.h
+++ b/src/pystack/_pystack/cpython/frame.h
@@ -39,7 +39,7 @@ namespace Python3_7 {
 typedef struct _pyframeobject
 {
     PyObject_VAR_HEAD struct _pyframeobject* f_back;
-    PyCodeObject* f_code;
+    PyObject* f_code;
     PyObject* f_builtins;
     PyObject* f_globals;
     PyObject* f_locals;
@@ -64,7 +64,7 @@ typedef signed char PyFrameState;
 typedef struct _pyframeobject
 {
     PyObject_VAR_HEAD struct _pyframeobject* f_back;
-    PyCodeObject* f_code;
+    PyObject* f_code;
     PyObject* f_builtins;
     PyObject* f_globals;
     PyObject* f_locals;
@@ -125,13 +125,5 @@ typedef struct _interpreter_frame
 } PyFrameObject;
 
 }  // namespace Python3_12
-
-typedef union {
-    Python2::PyFrameObject v2;
-    Python3_7::PyFrameObject v3_7;
-    Python3_10::PyFrameObject v3_10;
-    Python3_11::PyFrameObject v3_11;
-    Python3_12::PyFrameObject v3_12;
-} PyFrameObject;
 
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/gc.h
+++ b/src/pystack/_pystack/cpython/gc.h
@@ -106,10 +106,4 @@ struct _gc_runtime_state
 };
 
 }  // namespace Python3_13
-
-typedef union {
-    struct Python3_7::_gc_runtime_state v3_7;
-    struct Python3_8::_gc_runtime_state v3_8;
-    struct Python3_13::_gc_runtime_state v3_13;
-} GCRuntimeState;
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/interpreter.h
+++ b/src/pystack/_pystack/cpython/interpreter.h
@@ -338,15 +338,4 @@ typedef struct _is
     struct _import_state imports;
 } PyInterpreterState;
 }  // namespace Python3_13
-
-typedef union {
-    Python2::PyInterpreterState v2;
-    Python3_5::PyInterpreterState v3_5;
-    Python3_7::PyInterpreterState v3_7;
-    Python3_8::PyInterpreterState v3_8;
-    Python3_9::PyInterpreterState v3_9;
-    Python3_11::PyInterpreterState v3_11;
-    Python3_12::PyInterpreterState v3_12;
-    Python3_13::PyInterpreterState v3_13;
-} PyInterpreterState;
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/object.h
+++ b/src/pystack/_pystack/cpython/object.h
@@ -205,12 +205,6 @@ typedef struct _typeobject
 } PyTypeObject;
 }  // namespace Python3_8
 
-typedef union {
-    Python2::PyTypeObject v2;
-    Python3_3::PyTypeObject v3_3;
-    Python3_8::PyTypeObject v3_8;
-} PyTypeObject;
-
 /* These flags are used to determine if a type is a subclass. */
 constexpr long Pystack_TPFLAGS_INT_SUBCLASS = 1ul << 23u;
 constexpr long Pystack_TPFLAGS_LONG_SUBCLASS = 1ul << 24u;

--- a/src/pystack/_pystack/cpython/runtime.h
+++ b/src/pystack/_pystack/cpython/runtime.h
@@ -105,13 +105,15 @@ struct _ceval_runtime_state
     struct _gil_runtime_state gil;
 };
 
+struct PyThreadState;
+
 typedef struct pyruntimestate
 {
     int preinitializing;
     int preinitialized;
     int core_initialized;
     int initialized;
-    PyThreadState* finalizing;
+    void* finalizing;
 
     struct pyinterpreters
     {
@@ -171,7 +173,7 @@ typedef struct pyruntimestate
     int preinitialized;
     int core_initialized;
     int initialized;
-    PyThreadState* finalizing;
+    void* finalizing;
 
     struct pyinterpreters
     {

--- a/src/pystack/_pystack/cpython/string.h
+++ b/src/pystack/_pystack/cpython/string.h
@@ -109,14 +109,4 @@ typedef struct
 
 }  // namespace Python3_12
 
-typedef union {
-    Python3::PyBytesObject v3;
-} PyBytesObject;
-
-typedef union {
-    Python2::PyUnicodeObject v2;
-    Python3::PyUnicodeObject v3;
-    Python3_12::PyUnicodeObject v3_12;
-} PyUnicodeObject;
-
 }  // namespace pystack

--- a/src/pystack/_pystack/cpython/thread.h
+++ b/src/pystack/_pystack/cpython/thread.h
@@ -295,18 +295,4 @@ typedef struct _pythreadstate
 } PyThreadState;
 }  // namespace Python3_13
 
-typedef union {
-    Python2::PyThreadState v2;
-    Python3_4::PyThreadState v3_4;
-    Python3_7::PyThreadState v3_7;
-    Python3_11::PyThreadState v3_11;
-    Python3_12::PyThreadState v3_12;
-    Python3_13::PyThreadState v3_13;
-} PyThreadState;
-
-union CFrame {
-    Python3_11::CFrame v3_11;
-    Python3_12::CFrame v3_12;
-};
-
 }  // namespace pystack

--- a/src/pystack/_pystack/mem.cpp
+++ b/src/pystack/_pystack/mem.cpp
@@ -398,7 +398,7 @@ CorefileRemoteMemoryManager::StatusCode
 CorefileRemoteMemoryManager::getMemoryLocationFromCore(remote_addr_t addr, off_t* offset_in_file) const
 {
     auto corefile_it = std::find_if(d_vmaps.cbegin(), d_vmaps.cend(), [&](auto& map) {
-        return (map.Start() <= addr && addr <= map.End()) && (map.FileSize() != 0 && map.Offset() != 0);
+        return (map.Start() <= addr && addr < map.End()) && (map.FileSize() != 0 && map.Offset() != 0);
     });
     if (corefile_it == d_vmaps.cend()) {
         return StatusCode::ERROR;

--- a/src/pystack/_pystack/process.cpp
+++ b/src/pystack/_pystack/process.cpp
@@ -619,9 +619,9 @@ AbstractProcessManager::warnIfOffsetsAreMismatched() const
     if ((d_py_v->py_runtime.*size_offset).offset                                                        \
         && ((uint64_t)offsets().pystack_struct.size > py_runtime.getField(size_offset)))                \
     {                                                                                                   \
-        LOG(WARNING) << "Debug offsets mismatch: " #pystack_struct ".size "                             \
-                     << offsets().pystack_struct.size << " > " << py_runtime.getField(size_offset)      \
-                     << " reported by CPython";                                                         \
+        LOG(INFO) << "Debug offsets mismatch: compiled-in " << sizeof(void*) * 8 << "-bit python3."     \
+                  << d_minor << " " #pystack_struct ".size " << offsets().pystack_struct.size << " > "  \
+                  << py_runtime.getField(size_offset) << " loaded from _Py_DebugOffsets";               \
     } else                                                                                              \
         do {                                                                                            \
         } while (0)
@@ -630,9 +630,10 @@ AbstractProcessManager::warnIfOffsetsAreMismatched() const
     if ((d_py_v->py_runtime.*field_offset_offset).offset                                                \
         && (uint64_t)offsets().pystack_field.offset != py_runtime.getField(field_offset_offset))        \
     {                                                                                                   \
-        LOG(WARNING) << "Debug offsets mismatch: " #pystack_field << " "                                \
-                     << offsets().pystack_field.offset                                                  \
-                     << " != " << py_runtime.getField(field_offset_offset) << " reported by CPython";   \
+        LOG(INFO) << "Debug offsets mismatch: compiled-in " << sizeof(void*) * 8 << "-bit python3."     \
+                  << d_minor << " " #pystack_field << " " << offsets().pystack_field.offset             \
+                  << " != " << py_runtime.getField(field_offset_offset)                                 \
+                  << " loaded from _Py_DebugOffsets";                                                   \
     } else                                                                                              \
         do {                                                                                            \
         } while (0)

--- a/src/pystack/_pystack/process.h
+++ b/src/pystack/_pystack/process.h
@@ -92,21 +92,6 @@ class AbstractProcessManager : public std::enable_shared_from_this<AbstractProce
     bool versionIsAtLeast(int required_major, int required_minor) const;
     const python_v& offsets() const;
 
-    template<typename OffsetsStruct, typename FieldPointer>
-    inline offset_t getFieldOffset(FieldPointer OffsetsStruct::*field) const
-    {
-        return (d_py_v->get<OffsetsStruct>().*field).offset;
-    }
-
-    template<typename OffsetsStruct, typename FieldPointer>
-    inline const typename FieldPointer::Type&
-    getField(const typename OffsetsStruct::Structure& obj, FieldPointer OffsetsStruct::*field) const
-    {
-        offset_t offset = getFieldOffset(field);
-        auto address = reinterpret_cast<const char*>(&obj) + offset;
-        return *reinterpret_cast<const typename FieldPointer::Type*>(address);
-    }
-
   protected:
     // Data members
     pid_t d_pid;

--- a/src/pystack/_pystack/process.h
+++ b/src/pystack/_pystack/process.h
@@ -78,6 +78,7 @@ class AbstractProcessManager : public std::enable_shared_from_this<AbstractProce
     remote_addr_t findInterpreterStateFromPyRuntime(remote_addr_t runtime_addr) const;
     remote_addr_t findInterpreterStateFromSymbols() const;
     remote_addr_t findInterpreterStateFromElfData() const;
+    remote_addr_t findInterpreterStateFromDebugOffsets() const;
     remote_addr_t findSymbol(const std::string& symbol) const;
     ssize_t copyMemoryFromProcess(remote_addr_t addr, size_t size, void* destination) const;
     template<typename T>

--- a/src/pystack/_pystack/process.pxd
+++ b/src/pystack/_pystack/process.pxd
@@ -30,7 +30,8 @@ cdef extern from "process.h" namespace "pystack":
         vector[int] Tids() except+
         InterpreterStatus isInterpreterActive() except+
         pair[int, int] findPythonVersion()
-        void setPythonVersion(pair[int, int] version)
+        void setPythonVersion(pair[int, int] version) except +
+        void setPythonVersionFromDebugOffsets() except +
 
     cdef cppclass ProcessManager(AbstractProcessManager):
         ProcessManager(int pid, shared_ptr[ProcessTracer] tracer, shared_ptr[ProcessAnalyzer] analyzer, vector[VirtualMap] memory_maps, MemoryMapInformation map_info) except+

--- a/src/pystack/_pystack/process.pxd
+++ b/src/pystack/_pystack/process.pxd
@@ -24,6 +24,7 @@ cdef extern from "process.h" namespace "pystack":
         remote_addr_t scanBSS() except+
         remote_addr_t scanHeap() except+
         remote_addr_t scanAllAnonymousMaps() except+
+        remote_addr_t findInterpreterStateFromDebugOffsets() except+
         remote_addr_t findInterpreterStateFromSymbols() except+
         remote_addr_t findInterpreterStateFromElfData() except+
         ssize_t copyMemoryFromProcess(remote_addr_t addr, ssize_t size, void *destination) except+

--- a/src/pystack/_pystack/pycode.cpp
+++ b/src/pystack/_pystack/pycode.cpp
@@ -105,11 +105,11 @@ static LocationInfo
 getLocationInfo(
         const std::shared_ptr<const AbstractProcessManager>& manager,
         remote_addr_t code_addr,
-        PyCodeObject& code,
+        Structure<py_code_v>& code,
         uintptr_t last_instruction_index)
 {
-    int code_lineno = manager->getField(code, &py_code_v::o_firstlineno);
-    remote_addr_t lnotab_addr = manager->getField(code, &py_code_v::o_lnotab);
+    int code_lineno = code.getField(&py_code_v::o_firstlineno);
+    remote_addr_t lnotab_addr = code.getField(&py_code_v::o_lnotab);
     LOG(DEBUG) << std::hex << std::showbase << "Copying lnotab data from address " << lnotab_addr;
     std::string lnotab = manager->getBytesFromAddress(lnotab_addr);
 
@@ -121,7 +121,7 @@ getLocationInfo(
     // Check out https://github.com/python/cpython/blob/main/Objects/lnotab_notes.txt for the format of
     // the lnotab table in different versions of the interpreter.
     if (manager->versionIsAtLeast(3, 11)) {
-        uintptr_t code_adaptive = code_addr + manager->getFieldOffset(&py_code_v::o_code_adaptive);
+        uintptr_t code_adaptive = code.getFieldRemoteAddress(&py_code_v::o_code_adaptive);
         ptrdiff_t addrq =
                 (reinterpret_cast<uint16_t*>(last_instruction_index)
                  - reinterpret_cast<uint16_t*>(code_adaptive));
@@ -178,9 +178,8 @@ isValid(const std::shared_ptr<const AbstractProcessManager>& manager, remote_add
             }
             return false;
         } else {
-            PyObject obj;
-            manager->copyObjectFromProcess(addr, &obj);
-            return reinterpret_cast<remote_addr_t>(obj.ob_type) == pycodeobject_addr;
+            Structure<py_object_v> obj(manager, addr);
+            return obj.getField(&py_object_v::o_ob_type) == pycodeobject_addr;
         }
     }
     return true;
@@ -191,7 +190,6 @@ CodeObject::CodeObject(
         remote_addr_t addr,
         uintptr_t lasti)
 {
-    PyCodeObject code;
     if (!isValid(manager, addr)) {
         d_filename = "???";
         d_scope = "???";
@@ -200,15 +198,15 @@ CodeObject::CodeObject(
         return;
     }
     LOG(DEBUG) << std::hex << std::showbase << "Copying code struct from address " << addr;
-    manager->copyMemoryFromProcess(addr, manager->offsets().py_code.size, &code);
+    Structure<py_code_v> code(manager, addr);
 
-    remote_addr_t filename_addr = manager->getField(code, &py_code_v::o_filename);
+    remote_addr_t filename_addr = code.getField(&py_code_v::o_filename);
     LOG(DEBUG) << std::hex << std::showbase << "Copying filename Python string from address "
                << filename_addr;
     d_filename = manager->getStringFromAddress(filename_addr);
     LOG(DEBUG) << "Code object filename: " << d_filename;
 
-    remote_addr_t name_addr = manager->getField(code, &py_code_v::o_name);
+    remote_addr_t name_addr = code.getField(&py_code_v::o_name);
     LOG(DEBUG) << std::hex << std::showbase << "Copying code name Python string from address "
                << name_addr;
     d_scope = manager->getStringFromAddress(name_addr);
@@ -220,11 +218,11 @@ CodeObject::CodeObject(
                << d_location_info.end_lineno << ") column_range=(" << d_location_info.column << ", "
                << d_location_info.end_column << ")";
 
-    d_narguments = manager->getField(code, &py_code_v::o_argcount);
+    d_narguments = code.getField(&py_code_v::o_argcount);
     LOG(DEBUG) << "Code object n arguments: " << d_narguments;
 
     LOG(DEBUG) << "Copying variable names";
-    remote_addr_t varnames_addr = manager->getField(code, &py_code_v::o_varnames);
+    remote_addr_t varnames_addr = code.getField(&py_code_v::o_varnames);
     TupleObject varnames(manager, varnames_addr);
     std::transform(
             varnames.Items().cbegin(),

--- a/src/pystack/_pystack/pyframe.h
+++ b/src/pystack/_pystack/pyframe.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "memory"
-#include "unordered_map"
+#include <memory>
+#include <unordered_map>
 
 #include "mem.h"
 #include "process.h"
 #include "pycode.h"
+#include "structure.h"
 
 namespace pystack {
 
@@ -32,14 +33,15 @@ class FrameObject
 
   private:
     // Methods
-    static bool
-    getIsShim(const std::shared_ptr<const AbstractProcessManager>& manager, const PyFrameObject& frame);
+    static bool getIsShim(
+            const std::shared_ptr<const AbstractProcessManager>& manager,
+            Structure<py_frame_v>& frame);
 
     static std::unique_ptr<CodeObject>
-    getCode(const std::shared_ptr<const AbstractProcessManager>& manager, const PyFrameObject& frame);
+    getCode(const std::shared_ptr<const AbstractProcessManager>& manager, Structure<py_frame_v>& frame);
 
     bool
-    isEntry(const std::shared_ptr<const AbstractProcessManager>& manager, const PyFrameObject& frame);
+    isEntry(const std::shared_ptr<const AbstractProcessManager>& manager, Structure<py_frame_v>& frame);
 
     // Data members
     const std::shared_ptr<const AbstractProcessManager> d_manager{};

--- a/src/pystack/_pystack/pythread.cpp
+++ b/src/pystack/_pystack/pythread.cpp
@@ -274,13 +274,10 @@ PyThread::calculateGilStatus(
             Structure<py_is_v> interp(manager, is_addr);
 
             auto gil_addr = interp.getField(&py_is_v::o_gil_runtime_state);
+            Structure<py_gilruntimestate_v> gil(manager, gil_addr);
 
-            Python3_9::_gil_runtime_state gil;
-            manager->copyObjectFromProcess(gil_addr, &gil);
-
-            auto locked = *reinterpret_cast<int*>(&gil.locked);
-            auto holder = *reinterpret_cast<remote_addr_t*>(&gil.last_holder);
-
+            auto locked = gil.getField(&py_gilruntimestate_v::o_locked);
+            auto holder = gil.getField(&py_gilruntimestate_v::o_last_holder);
             return (locked && holder == d_addr ? GilStatus::HELD : GilStatus::NOT_HELD);
         } else if (manager->versionIsAtLeast(3, 8)) {
             // Fast, exact method by checking the gilstate structure in _PyRuntime

--- a/src/pystack/_pystack/pythread.h
+++ b/src/pystack/_pystack/pythread.h
@@ -47,8 +47,9 @@ class PyThread : public Thread
     GCStatus isGCCollecting() const;
 
     // Static Methods
-    static remote_addr_t
-    getFrameAddr(const std::shared_ptr<const AbstractProcessManager>& manager, const PyThreadState& ts);
+    static remote_addr_t getFrameAddr(
+            const std::shared_ptr<const AbstractProcessManager>& manager,
+            Structure<py_thread_v>& ts);
 
   private:
     // Data members
@@ -62,10 +63,10 @@ class PyThread : public Thread
 
     // Methods
     GilStatus calculateGilStatus(
-            PyThreadState& ts,
+            Structure<py_thread_v>& ts,
             const std::shared_ptr<const AbstractProcessManager>& manager) const;
     GCStatus calculateGCStatus(
-            PyThreadState& ts,
+            Structure<py_thread_v>& ts,
             const std::shared_ptr<const AbstractProcessManager>& manager) const;
 
     // Static Methods
@@ -74,7 +75,7 @@ class PyThread : public Thread
             unsigned long pthread_id);
     static int getThreadTid(
             const std::shared_ptr<const AbstractProcessManager>& manager,
-            remote_addr_t thread_addr,
+            Structure<py_thread_v>& ts,
             unsigned long pthread_id);
 };
 

--- a/src/pystack/_pystack/pytypes.h
+++ b/src/pystack/_pystack/pytypes.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <variant>
 #include <vector>
 
 #include "mem.h"
 #include "process.h"
-#include "pycompat.h"
+#include "structure.h"
 
 namespace pystack {
 
@@ -181,7 +180,7 @@ class Object
     bool toBool() const;
     long toInteger() const;
     double toFloat() const;
-    std::string guessClassName(PyTypeObject& type) const;
+    std::string guessClassName(Structure<py_type_v>& type) const;
 };
 
 }  // namespace pystack

--- a/src/pystack/_pystack/structure.h
+++ b/src/pystack/_pystack/structure.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "process.h"
+
+namespace pystack {
+
+template<typename OffsetsStruct>
+class Structure
+{
+  public:
+    // Constructors
+    Structure(std::shared_ptr<const AbstractProcessManager> manager, remote_addr_t addr);
+    Structure(const Structure&) = delete;
+    Structure& operator=(const Structure&) = delete;
+
+    // Methods
+    void copyFromRemote();
+
+    template<typename FieldPointer>
+    remote_addr_t getFieldRemoteAddress(FieldPointer OffsetsStruct::*field) const;
+
+    template<typename FieldPointer>
+    const typename FieldPointer::Type& getField(FieldPointer OffsetsStruct::*field);
+
+  private:
+    // Data members
+    std::shared_ptr<const AbstractProcessManager> d_manager;
+    remote_addr_t d_addr;
+    ssize_t d_size;
+    std::array<char, 512> d_footprintbuf;
+    std::vector<char> d_heapbuf;
+    char* d_buf;
+};
+
+template<typename OffsetsStruct>
+inline Structure<OffsetsStruct>::Structure(
+        std::shared_ptr<const AbstractProcessManager> manager,
+        remote_addr_t addr)
+: d_manager(manager)
+, d_addr(addr)
+, d_size(d_manager->offsets().get<OffsetsStruct>().size)
+, d_buf{}
+{
+}
+
+template<typename OffsetsStruct>
+inline void
+Structure<OffsetsStruct>::copyFromRemote()
+{
+    if (d_buf) {
+        return;  // already copied
+    }
+
+    if (d_size < 512) {
+        d_buf = &d_footprintbuf[0];
+    } else {
+        d_heapbuf.resize(d_size);
+        d_buf = &d_heapbuf[0];
+    }
+    d_manager->copyMemoryFromProcess(d_addr, d_size, d_buf);
+}
+
+template<typename OffsetsStruct>
+template<typename FieldPointer>
+inline remote_addr_t
+Structure<OffsetsStruct>::getFieldRemoteAddress(FieldPointer OffsetsStruct::*field) const
+{
+    offset_t offset = (d_manager->offsets().get<OffsetsStruct>().*field).offset;
+    return d_addr + offset;
+}
+
+template<typename OffsetsStruct>
+template<typename FieldPointer>
+inline const typename FieldPointer::Type&
+Structure<OffsetsStruct>::getField(FieldPointer OffsetsStruct::*field)
+{
+    copyFromRemote();
+    offset_t offset = (d_manager->offsets().get<OffsetsStruct>().*field).offset;
+    if (d_size < 0 || (size_t)d_size < sizeof(typename FieldPointer::Type)
+        || d_size - sizeof(typename FieldPointer::Type) < offset)
+    {
+        abort();
+    }
+    auto address = d_buf + offset;
+    return *reinterpret_cast<const typename FieldPointer::Type*>(address);
+}
+
+}  // namespace pystack

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -238,6 +238,7 @@ py_runtimev313()
             {},
             {},
             offsetof(T, debug_offsets.cookie),
+            offsetof(T, debug_offsets.version),
             offsetof(T, debug_offsets.runtime_state.size),
             offsetof(T, debug_offsets.runtime_state.finalizing),
             offsetof(T, debug_offsets.runtime_state.interpreters_head),

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -193,6 +193,17 @@ py_cframe()
 }
 
 template<class T>
+constexpr py_gilruntimestate_v
+py_gilruntimestate()
+{
+    return {
+            sizeof(T),
+            offsetof(T, locked),
+            offsetof(T, last_holder),
+    };
+}
+
+template<class T>
 constexpr py_runtime_v
 py_runtime()
 {
@@ -623,6 +634,7 @@ python_v python_v3_12 = {
         py_runtimev312<Python3_12::PyRuntimeState>(),
         py_gc<Python3_8::_gc_runtime_state>(),
         py_cframe<Python3_12::CFrame>(),
+        py_gilruntimestate<Python3_9::_gil_runtime_state>(),
 };
 
 // ---- Python 3.13 ------------------------------------------------------------
@@ -646,6 +658,7 @@ python_v python_v3_13 = {
         py_runtimev313<Python3_13::PyRuntimeState>(),
         py_gc<Python3_13::_gc_runtime_state>(),
         py_cframe<Python3_12::CFrame>(),
+        py_gilruntimestate<Python3_9::_gil_runtime_state>(),
 };
 
 // -----------------------------------------------------------------------------

--- a/src/pystack/_pystack/version.cpp
+++ b/src/pystack/_pystack/version.cpp
@@ -226,6 +226,7 @@ py_runtimev313()
             offsetof(T, interpreters.head),
             {},
             {},
+            offsetof(T, debug_offsets.cookie),
             offsetof(T, debug_offsets.runtime_state.size),
             offsetof(T, debug_offsets.runtime_state.finalizing),
             offsetof(T, debug_offsets.runtime_state.interpreters_head),

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -133,6 +133,7 @@ struct py_runtime_v
     FieldOffset<uintptr_t> o_tstate_current;
 
     FieldOffset<char[8]> o_dbg_off_cookie;
+    FieldOffset<uint64_t> o_dbg_off_py_version_hex;
 
     FieldOffset<uint64_t> o_dbg_off_runtime_state_struct_size;
     FieldOffset<uint64_t> o_dbg_off_runtime_state_finalizing;

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -142,8 +142,11 @@ struct py_runtime_v
     ssize_t size;
     FieldOffset<remote_addr_t> o_finalizing;
     FieldOffset<remote_addr_t> o_interp_head;
-    FieldOffset<GCRuntimeState> o_gc;
+    FieldOffset<char> o_gc;  // Using char because we can only use the offset,
+                             // as the size and members change between versions
     FieldOffset<uintptr_t> o_tstate_current;
+
+    FieldOffset<char[8]> o_dbg_off_cookie;
 
     FieldOffset<uint64_t> o_dbg_off_runtime_state_struct_size;
     FieldOffset<uint64_t> o_dbg_off_runtime_state_finalizing;
@@ -222,7 +225,8 @@ struct py_is_v
     ssize_t size;
     FieldOffset<remote_addr_t> o_next;
     FieldOffset<remote_addr_t> o_tstate_head;
-    FieldOffset<GCRuntimeState> o_gc;
+    FieldOffset<char> o_gc;  // Using char because we can only use the offset,
+                             // as the size and members change between versions
     FieldOffset<remote_addr_t> o_modules;
     FieldOffset<remote_addr_t> o_sysdict;
     FieldOffset<remote_addr_t> o_builtins;

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -229,6 +229,13 @@ struct py_cframe_v
     FieldOffset<remote_addr_t> current_frame;
 };
 
+struct py_gilruntimestate_v
+{
+    ssize_t size;
+    FieldOffset<int> o_locked;
+    FieldOffset<remote_addr_t> o_last_holder;
+};
+
 struct python_v
 {
     py_tuple_v py_tuple;
@@ -249,6 +256,7 @@ struct python_v
     py_runtime_v py_runtime;
     py_gc_v py_gc;
     py_cframe_v py_cframe;
+    py_gilruntimestate_v py_gilruntimestate;
 
     template<typename T>
     inline const T& get() const;
@@ -279,6 +287,7 @@ define_python_v_get_specialization(py_is);
 define_python_v_get_specialization(py_runtime);
 define_python_v_get_specialization(py_gc);
 define_python_v_get_specialization(py_cframe);
+define_python_v_get_specialization(py_gilruntimestate);
 
 #undef define_python_v_get_specialization
 

--- a/src/pystack/_pystack/version.h
+++ b/src/pystack/_pystack/version.h
@@ -20,7 +20,6 @@ struct FieldOffset
 
 struct py_tuple_v
 {
-    typedef PyTupleObject Structure;
     ssize_t size;
     FieldOffset<Py_ssize_t> o_ob_size;
     FieldOffset<PyObject* [1]> o_ob_item;
@@ -28,7 +27,6 @@ struct py_tuple_v
 
 struct py_list_v
 {
-    typedef PyListObject Structure;
     ssize_t size;
     FieldOffset<Py_ssize_t> o_ob_size;
     FieldOffset<PyObject**> o_ob_item;
@@ -36,7 +34,6 @@ struct py_list_v
 
 struct py_dict_v
 {
-    typedef Python3::PyDictObject Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_ma_keys;
     FieldOffset<remote_addr_t> o_ma_values;
@@ -44,7 +41,6 @@ struct py_dict_v
 
 struct py_dictkeys_v
 {
-    typedef PyDictKeysObject Structure;
     ssize_t size;
     FieldOffset<Py_ssize_t> o_dk_size;
     FieldOffset<uint8_t> o_dk_kind;
@@ -54,21 +50,18 @@ struct py_dictkeys_v
 
 struct py_dictvalues_v
 {
-    typedef PyDictValuesObject Structure;
     ssize_t size;
     FieldOffset<remote_addr_t[1]> o_values;
 };
 
 struct py_float_v
 {
-    typedef PyFloatObject Structure;
     ssize_t size;
     FieldOffset<double> o_ob_fval;
 };
 
 struct py_long_v
 {
-    typedef _PyLongObject Structure;
     ssize_t size;
     FieldOffset<Py_ssize_t> o_ob_size;
     FieldOffset<digit[1]> o_ob_digit;
@@ -76,7 +69,6 @@ struct py_long_v
 
 struct py_bytes_v
 {
-    typedef PyBytesObject Structure;
     ssize_t size;
     FieldOffset<Py_ssize_t> o_ob_size;
     FieldOffset<char[1]> o_ob_sval;
@@ -84,7 +76,6 @@ struct py_bytes_v
 
 struct py_unicode_v
 {
-    typedef PyUnicodeObject Structure;
     ssize_t size;
     FieldOffset<Python3::_PyUnicode_State> o_state;
     FieldOffset<Py_ssize_t> o_length;
@@ -93,14 +84,12 @@ struct py_unicode_v
 
 struct py_object_v
 {
-    typedef PyObject Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_ob_type;
 };
 
 struct py_code_v
 {
-    typedef PyCodeObject Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_filename;
     FieldOffset<remote_addr_t> o_name;
@@ -113,7 +102,6 @@ struct py_code_v
 
 struct py_frame_v
 {
-    typedef PyFrameObject Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_back;
     FieldOffset<remote_addr_t> o_code;
@@ -126,7 +114,6 @@ struct py_frame_v
 
 struct py_thread_v
 {
-    typedef PyThreadState Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_prev;
     FieldOffset<remote_addr_t> o_next;
@@ -138,7 +125,6 @@ struct py_thread_v
 
 struct py_runtime_v
 {
-    typedef PyRuntimeState Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_finalizing;
     FieldOffset<remote_addr_t> o_interp_head;
@@ -212,7 +198,6 @@ struct py_runtime_v
 
 struct py_type_v
 {
-    typedef PyTypeObject Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_tp_name;
     FieldOffset<remote_addr_t> o_tp_repr;
@@ -221,7 +206,6 @@ struct py_type_v
 
 struct py_is_v
 {
-    typedef PyInterpreterState Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_next;
     FieldOffset<remote_addr_t> o_tstate_head;
@@ -235,14 +219,12 @@ struct py_is_v
 
 struct py_gc_v
 {
-    typedef GCRuntimeState Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> o_collecting;
 };
 
 struct py_cframe_v
 {
-    typedef CFrame Structure;
     ssize_t size;
     FieldOffset<remote_addr_t> current_frame;
 };

--- a/src/pystack/process.py
+++ b/src/pystack/process.py
@@ -19,8 +19,12 @@ LIBPYTHON_REGEXP = re.compile(
     r".*libpython(?P<major>\d+)\.(?P<minor>\d+).*", re.IGNORECASE
 )
 
+# Strings like "3.8.10 (default, May 26 2023, 14:05:08)"
+# or "2.7.18rc1 (v2.7.18rc1:8d21aa21f2, Apr 20 2020, 13:19:08)"
+# or "3.13.0+ experimental free-threading build (Python)"
 BSS_VERSION_REGEXP = re.compile(
-    rb"((2|3)\.(\d+)\.(\d{1,2}))((a|b|c|rc)\d{1,2})?\+? (\(.{1,64}\))"
+    rb"((2|3)\.(\d+)\.(\d{1,2}))((a|b|c|rc)\d{1,2})?\+?"
+    rb"(?: experimental free-threading build)? (\(.{1,64}\))"
 )
 
 LOGGER = logging.getLogger(__file__)

--- a/tests/integration/test_gil.py
+++ b/tests/integration/test_gil.py
@@ -1,4 +1,7 @@
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from pystack.engine import get_process_threads
 from pystack.engine import get_process_threads_for_core
@@ -12,6 +15,15 @@ TEST_MULTIPLE_THREADS_GIL_FILE = (
 TEST_MULTIPLE_THREADS_FILE = Path(__file__).parent / "multiple_thread_program.py"
 TEST_SINGLE_THREAD_GIL_FILE = Path(__file__).parent / "single_thread_program_gil.py"
 TEST_SINGLE_THREAD_FILE = Path(__file__).parent / "single_thread_program.py"
+
+
+@pytest.fixture(autouse=True)
+def enable_gil_if_free_threading(python, monkeypatch):
+    _, python_executable = python
+    proc = subprocess.run([python_executable, "-Xgil=1", "-cpass"], capture_output=True)
+    free_threading = proc.returncode == 0
+    if free_threading:
+        monkeypatch.setenv("PYTHON_GIL", "1")
 
 
 @ALL_PYTHONS

--- a/tests/integration/test_local_variables.py
+++ b/tests/integration/test_local_variables.py
@@ -573,7 +573,6 @@ import time
 
 class ListObject(ctypes.Structure):
     _fields_ = [
-        ("ob_refcnt", ctypes.c_ssize_t),
         ("ob_type", ctypes.c_void_p),
         ("ob_size", ctypes.c_ssize_t),
         ("ob_item", ctypes.c_void_p),
@@ -581,12 +580,15 @@ class ListObject(ctypes.Structure):
 
 class TupleObject(ctypes.Structure):
     _fields_ = [
-        ("ob_refcnt", ctypes.c_ssize_t),
         ("ob_type", ctypes.c_void_p),
         ("ob_size", ctypes.c_ssize_t),
         ("ob_item0", ctypes.c_void_p),
         ("ob_item1", ctypes.c_void_p),
     ]
+
+def ob_type_field(obj):
+    # Assume ob_type is the last field of PyObject
+    return id(obj) + sys.getsizeof(None) - ctypes.sizeof(ctypes.c_void_p)
 
 def main():
     bad_type = (1, 2, 3)
@@ -594,10 +596,10 @@ def main():
     nullelem = (7, 8, 9)
     bad_list = [0, 1, 2]
 
-    TupleObject.from_address(id(bad_type)).ob_type = 0xded
-    TupleObject.from_address(id(bad_elem)).ob_item1 = 0xbad
-    TupleObject.from_address(id(nullelem)).ob_item1 = 0x0
-    ListObject.from_address(id(bad_list)).ob_item = 0x0
+    TupleObject.from_address(ob_type_field(bad_type)).ob_type = 0xded
+    TupleObject.from_address(ob_type_field(bad_elem)).ob_item1 = 0xbad
+    TupleObject.from_address(ob_type_field(nullelem)).ob_item1 = 0x0
+    ListObject.from_address(ob_type_field(bad_list)).ob_item = 0x0
 
     fifo = sys.argv[1]
     with open(sys.argv[1], "w") as fifo:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -20,9 +20,20 @@ if sys.version_info < (3, 10):  # pragma: no cover
 elif sys.version_info < (3, 11):  # pragma: no cover
     STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA, StackMethod.HEAP)
     CORE_STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA)
-else:  # pragma: no cover
+elif sys.version_info < (3, 13):  # pragma: no cover
     STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA)
     CORE_STACK_METHODS = (StackMethod.SYMBOLS, StackMethod.ELF_DATA)
+else:  # pragma: no cover
+    STACK_METHODS = (
+        StackMethod.DEBUG_OFFSETS,
+        StackMethod.SYMBOLS,
+        StackMethod.ELF_DATA,
+    )
+    CORE_STACK_METHODS = (
+        StackMethod.DEBUG_OFFSETS,
+        StackMethod.SYMBOLS,
+        StackMethod.ELF_DATA,
+    )
 
 
 @pytest.mark.parametrize("method", STACK_METHODS)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -218,6 +218,7 @@ def generate_all_pystack_combinations(
 ]:  # pragma: no cover
     if corefile:
         stack_methods = (
+            StackMethod.DEBUG_OFFSETS,
             StackMethod.SYMBOLS,
             StackMethod.BSS,
             StackMethod.ELF_DATA,
@@ -225,6 +226,7 @@ def generate_all_pystack_combinations(
         )
     else:
         stack_methods = (
+            StackMethod.DEBUG_OFFSETS,
             StackMethod.SYMBOLS,
             StackMethod.BSS,
             StackMethod.HEAP,
@@ -243,6 +245,10 @@ def generate_all_pystack_combinations(
         AVAILABLE_PYTHONS,
     ):
         (major_version, minor_version) = python.version
+        if method == StackMethod.DEBUG_OFFSETS and (
+            major_version < 3 or (major_version == 3 and minor_version < 13)
+        ):
+            continue
         if method == StackMethod.BSS and (
             major_version > 3 or (major_version == 3 and minor_version >= 10)
         ):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,6 +23,7 @@ TIMEOUT = 30
 PythonVersion = Tuple[Tuple[int, int], pathlib.Path]
 
 ALL_VERSIONS = [
+    ((3, 13), "python3.13t"),
     ((3, 13), "python3.13"),
     ((3, 12), "python3.12"),
     ((3, 11), "python3.11"),
@@ -44,6 +45,8 @@ def find_all_available_pythons() -> Iterable[Interpreter]:  # pragma: no cover
         versions = [((sys.version_info[0], sys.version_info[1]), sys.executable)]
     elif test_version is not None:
         major, minor = test_version.split(".")
+        if minor.endswith("t"):
+            minor = minor[:-1]
         versions = [((int(major), int(minor)), f"python{test_version}")]
     else:
         versions = ALL_VERSIONS


### PR DESCRIPTION
Python 3.13 adds a new `_Py_DebugOffsets` structure to `_PyRuntimeState` which tells us more or less everything that we need to know in order to decode the interpreter's data structures. Look for this structure and, if we find it, use the offsets contained in it rather than the offsets compiled into pystack at build time.

This allows us to decode stacks for interpreters with different build time sizes of different structures, including those running in a `python3.13t` free-threaded interpreter.