### PR TITLE
Fix decoding Python 3.13 stacks without symbols

### DIFF
--- a/src/pystack/_pystack/pycode.h
+++ b/src/pystack/_pystack/pycode.h
@@ -27,6 +27,7 @@ class CodeObject
             const std::shared_ptr<const AbstractProcessManager>& manager,
             remote_addr_t addr,
             uintptr_t lastli);
+    CodeObject(std::string filename, std::string scope, LocationInfo location_info);
 
     // Getters
     std::string Filename() const;
@@ -41,8 +42,6 @@ class CodeObject
     std::string d_scope;
     LocationInfo d_location_info;
     int d_narguments;
-
-  private:
     std::vector<std::string> d_varnames;
 };
 }  // namespace pystack

--- a/src/pystack/_pystack/pyframe.cpp
+++ b/src/pystack/_pystack/pyframe.cpp
@@ -71,7 +71,14 @@ FrameObject::getCode(
     } else {
         last_instruction = frame.getField(&py_frame_v::o_lasti);
     }
-    return std::make_unique<CodeObject>(manager, py_code_addr, last_instruction);
+    try {
+        return std::make_unique<CodeObject>(manager, py_code_addr, last_instruction);
+    } catch (const RemoteMemCopyError& ex) {
+        // This may not have been a code object at all, or it may have been
+        // trashed by memory corruption. Either way, indicate that we failed
+        // to understand what code this frame is running.
+        return std::make_unique<CodeObject>("???", "???", LocationInfo{0, 0, 0, 0});
+    }
 }
 
 bool


### PR DESCRIPTION
The eager `isValid` check that we implemented originally fails when symbols aren't available, as we're unable to look up `PyCode_Type` to compare the type of `f_executable` against it.

Instead, let's treat every `f_executable` as though it's a `PyCode_Type` without checking in advance. If it's not able to be interpreted as a `PyCode_Type`, we'll expect a `RemoteMemCopyError` from chasing an invalid pointer at some point, and can handle that the way that we have been handling `!isValid`.

Closes #205 

I tested this manually and confirmed that it does allow us to successfully decode a Python 3.13 core's Python stack even without the correct executable being available. There's no automated test added here, but in fairness the old `isValid` behavior that's being replaced was also not covered by any automated test.
