### PR TITLE
Handle failures to check if a file is ELF

### DIFF
--- a/news/221.bugfix.rst
+++ b/news/221.bugfix.rst
@@ -1,0 +1,1 @@
+Improve handling of core files where we cannot determine the executable.

--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -331,7 +331,7 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
     if args.executable is None:
         corefile_analyzer = CoreFileAnalyzer(corefile)
         executable = pathlib.Path(corefile_analyzer.extract_executable())
-        if not executable.exists() or not is_elf(executable):
+        if not is_elf(executable):
             first_map = next(
                 (
                     map
@@ -343,7 +343,6 @@ def process_core(parser: argparse.ArgumentParser, args: argparse.Namespace) -> N
             if (
                 first_map is not None
                 and first_map.path is not None
-                and first_map.path.exists()
                 and is_elf(first_map.path)
             ):
                 executable = first_map.path

--- a/src/pystack/process.py
+++ b/src/pystack/process.py
@@ -124,9 +124,12 @@ def get_python_version_for_core(
 
 def is_elf(filename: pathlib.Path) -> bool:
     "Return True if the given file is an ELF file"
-    elf_header = b"\x7fELF"
-    with open(filename, "br") as thefile:
-        return thefile.read(4) == elf_header
+    try:
+        elf_header = b"\x7fELF"
+        with open(filename, "br") as thefile:
+            return thefile.read(4) == elf_header
+    except OSError:
+        return False
 
 
 def get_thread_name(pid: int, tid: int) -> Optional[str]:

--- a/tests/integration/test_process.py
+++ b/tests/integration/test_process.py
@@ -132,6 +132,7 @@ def test_reattaching_to_already_traced_process(python, tmpdir):
     [
         (sys.executable, True),
         (__file__, False),
+        ("/etc", False),
     ],
 )
 def test_elf_checker(file, expected):


### PR DESCRIPTION
While attempting to find the executable for a core file, it's possible
that we extract the empty string from the core file where an executable
name ought to have been. In that case we construct a `pathlib.Path` with
the empty string, which happens to behave like a path of `.` - which is
a directory, not a file. This leads to failures in surprising places.

Since the core file may have been generated on a remote machine, or at
a distant point in time, we shouldn't assume that any file name found in
necessarily refers to a file that we can read just because it exists on
disk. It may have been replaced by a directory, or it may have its
permissions set up so that it's not readable by the user we're running
as. Rather than trusting that anything that we can `stat` must be a file
we can read, have our `is_elf` function treat any path from which we
fail to read as though it's not an ELF executable. This lets us continue
processing core files even if files they refer to can't be read by us,
letting us try fallbacks or otherwise attempt to make the best of
things.