### PR TITLE
Add error reason for core file load failures

### DIFF
--- a/src/pystack/_pystack/elf_common.cpp
+++ b/src/pystack/_pystack/elf_common.cpp
@@ -1,8 +1,10 @@
 #include <cassert>
+#include <cerrno>
 #include <cstring>
 #include <inttypes.h>
 #include <iomanip>
 #include <iostream>
+#include <string>
 #include <utility>
 
 #include "compat.h"
@@ -72,7 +74,8 @@ CoreFileAnalyzer::CoreFileAnalyzer(
 
     d_fd = open(d_filename.c_str(), O_RDONLY);
     if (d_fd == -1) {
-        throw ElfAnalyzerError("Failed to open ELF file " + d_filename);
+        throw ElfAnalyzerError(
+                "Failed to open ELF file '" + d_filename + "' (" + std::strerror(errno) + ")");
     }
 
     d_elf = elf_unique_ptr(elf_begin(d_fd, ELF_C_READ_MMAP, nullptr), elf_end);


### PR DESCRIPTION
Resolves #225 

**Describe your changes**
This update makes pystack's core file load failures more helpful by showing the error message instead of just "failed to open."

_Before:_
<img width="578" alt="image" src="https://github.com/user-attachments/assets/af48282f-4e8b-4693-a536-35101b8fd2ec" />

_Now:_
<img width="573" alt="image" src="https://github.com/user-attachments/assets/35f1b73b-5ed1-469b-a659-81b1dfec6fb8" />

**Testing performed**
Manual testing. Unable to add unit tests for this use case
