### PR TITLE
Exclude source code from wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,13 @@ setuptools.setup(
         compiler_directives=COMPILER_DIRECTIVES,
     ),
     install_requires=install_requires,
-    include_package_data=True,
+    include_package_data=False,
+    package_data={
+        "pystack": [
+            "pystack/*.pyi",
+            "pystack/*.typed",
+        ]
+    },
     entry_points={
         "console_scripts": ["pystack=pystack.__main__:main"],
     },


### PR DESCRIPTION
Resolves #231 

**Describe your changes**
Remove source files (cython/cpp) from the wheel

**Testing performed**
Manually tested the contents of the wheel and sdist before and after to ensure only the _pystack folder with the source files have been excluded from the wheel

```
((venv) ) root@codespaces-bfa09f:/workspaces/pystack# diff wheelnew wheelold
4a5
> pystack/_pystack.pyx
13a15,65
> pystack/_pystack/CMakeLists.txt
> pystack/_pystack/__init__.pxd
> pystack/_pystack/compat.h
> pystack/_pystack/corefile.cpp
> pystack/_pystack/corefile.h
> pystack/_pystack/corefile.pxd
> pystack/_pystack/elf_common.cpp
> pystack/_pystack/elf_common.h
> pystack/_pystack/elf_common.pxd
> pystack/_pystack/logging.cpp
> pystack/_pystack/logging.h
> pystack/_pystack/logging.pxd
> pystack/_pystack/mem.cpp
> pystack/_pystack/mem.h
> pystack/_pystack/mem.pxd
> pystack/_pystack/native_frame.h
> pystack/_pystack/native_frame.pxd
> pystack/_pystack/process.cpp
> pystack/_pystack/process.h
> pystack/_pystack/process.pxd
> pystack/_pystack/pycode.cpp
> pystack/_pystack/pycode.h
> pystack/_pystack/pycode.pxd
> pystack/_pystack/pycompat.h
> pystack/_pystack/pyframe.cpp
> pystack/_pystack/pyframe.h
> pystack/_pystack/pyframe.pxd
> pystack/_pystack/pythread.cpp
> pystack/_pystack/pythread.h
> pystack/_pystack/pythread.pxd
> pystack/_pystack/pytypes.cpp
> pystack/_pystack/pytypes.h
> pystack/_pystack/structure.h
> pystack/_pystack/unwinder.cpp
> pystack/_pystack/unwinder.h
> pystack/_pystack/version.cpp
> pystack/_pystack/version.h
> pystack/_pystack/cpython/code.h
> pystack/_pystack/cpython/dict.h
> pystack/_pystack/cpython/float.h
> pystack/_pystack/cpython/frame.h
> pystack/_pystack/cpython/gc.h
> pystack/_pystack/cpython/int.h
> pystack/_pystack/cpython/interpreter.h
> pystack/_pystack/cpython/list.h
> pystack/_pystack/cpython/object.h
> pystack/_pystack/cpython/pthread.h
> pystack/_pystack/cpython/runtime.h
> pystack/_pystack/cpython/string.h
> pystack/_pystack/cpython/thread.h
> pystack/_pystack/cpython/tuple.h
```

**Additional context**
N/A
