### PR TITLE
Fallback to /proc/PID/mem when process_vm_readv not in kernel

### DIFF
--- a/news/240.feature.rst
+++ b/news/240.feature.rst
@@ -1,0 +1,1 @@
+Support kernels that don't have CONFIG_CROSS_MEMORY_ATTACH set.

--- a/src/pystack/_pystack/mem.cpp
+++ b/src/pystack/_pystack/mem.cpp
@@ -228,7 +228,7 @@ ProcessMemoryManager::ProcessMemoryManager(pid_t pid)
 ssize_t
 ProcessMemoryManager::readChunk(remote_addr_t addr, size_t len, char* dst) const
 {
-    if (d_memfile) {
+    if (d_memfile || getenv("_PYSTACK_NO_PROCESS_VM_READV") != nullptr) {
         return readChunkThroughMemFile(addr, len, dst);
     } else {
         return readChunkDirect(addr, len, dst);

--- a/src/pystack/_pystack/mem.h
+++ b/src/pystack/_pystack/mem.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <fcntl.h>
+#include <fstream>
 #include <functional>
 #include <list>
 #include <memory>
@@ -12,7 +13,7 @@
 #include <sys/stat.h>
 #include <vector>
 
-#include <elf_common.h>
+#include "elf_common.h"
 
 namespace pystack {
 typedef uintptr_t remote_addr_t;
@@ -174,9 +175,12 @@ class ProcessMemoryManager : public AbstractRemoteMemoryManager
     pid_t d_pid;
     std::vector<VirtualMap> d_vmaps;
     mutable LRUCache d_lru_cache;
+    mutable std::ifstream d_memfile{};
 
     // Methods
     ssize_t readChunk(remote_addr_t addr, size_t len, char* dst) const;
+    ssize_t readChunkDirect(remote_addr_t addr, size_t len, char* dst) const;
+    ssize_t readChunkThroughMemFile(remote_addr_t addr, size_t len, char* dst) const;
 };
 
 struct SimpleVirtualMap

--- a/src/pystack/_pystack/mem.h
+++ b/src/pystack/_pystack/mem.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <fcntl.h>
-#include <fstream>
 #include <functional>
 #include <list>
 #include <memory>
@@ -16,6 +15,8 @@
 #include "elf_common.h"
 
 namespace pystack {
+
+using file_unique_ptr = std::unique_ptr<FILE, std::function<int(FILE*)>>;
 typedef uintptr_t remote_addr_t;
 
 struct RemoteMemCopyError : public std::exception
@@ -175,7 +176,7 @@ class ProcessMemoryManager : public AbstractRemoteMemoryManager
     pid_t d_pid;
     std::vector<VirtualMap> d_vmaps;
     mutable LRUCache d_lru_cache;
-    mutable std::ifstream d_memfile{};
+    mutable file_unique_ptr d_memfile;
 
     // Methods
     ssize_t readChunk(remote_addr_t addr, size_t len, char* dst) const;

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -38,12 +38,22 @@ else:  # pragma: no cover
 
 @pytest.mark.parametrize("method", STACK_METHODS)
 @pytest.mark.parametrize("blocking", [True, False], ids=["blocking", "non-blocking"])
-def test_simple_execution(method, blocking, tmpdir):
+@pytest.mark.parametrize(
+    "use_process_vm_readv", [True, False], ids=["process_vm_readv", "/proc/PID/mem"]
+)
+def test_simple_execution(method, blocking, use_process_vm_readv, tmpdir, monkeypatch):
     """Test that we can retrieve the thread state of a single process.
 
     This test is specially useful to run under valgrind or similar tools and to
     quickly check that the very basic functionality works as expected.
     """
+
+    # GIVEN
+    env_var = "_PYSTACK_NO_PROCESS_VM_READV"
+    if use_process_vm_readv:
+        monkeypatch.delenv(env_var, raising=False)
+    else:
+        monkeypatch.setenv(env_var, "1")
 
     # WHEN
     with spawn_child_process(


### PR DESCRIPTION
Resolves #238

**Describe your changes**
I've added an alternative implementation of `ProcessMemoryManager::readChunk` that uses the relevant `/proc/PID/mem` file and is fallen back to when `process_vm_readv` fails with `ENOSYS`.
Once the `/proc/PID/mem` file is open, subsequent reads are done only from there.

**Testing performed**

On my dev instance where my kernel does have `CONFIG_CROSS_MEMORY_ATTACH` set, I did various tests with small source changes. Such as forcing the fallback implementation to always be used. 

<details><summary>Details</summary>
<p>

```diff
diff --git a/src/pystack/_pystack/mem.cpp b/src/pystack/_pystack/mem.cpp
index e25c69f..5deda3d 100644
--- a/src/pystack/_pystack/mem.cpp
+++ b/src/pystack/_pystack/mem.cpp
@@ -229,11 +229,15 @@ ProcessMemoryManager::ProcessMemoryManager(pid_t pid)
 ssize_t
 ProcessMemoryManager::readChunk(remote_addr_t addr, size_t len, char* dst) const
 {
+#if 0
     if (d_memfile.is_open()) {
         return readChunkThroughMemFile(addr, len, dst);
     } else {
         return readChunkDirect(addr, len, dst);
     }
+#else
+        return readChunkThroughMemFile(addr, len, dst);
+#endif
 }
 
 ssize_t
```

</p>
</details> 


```shell
dan:~/src/pystack (support-missing-process_vm_readv) % python3 -c $'import time\nwhile True: time.sleep(1)' &
[1] 27161
dan:~/src/pystack (support-missing-process_vm_readv) % pystack remote $(pgrep python3)                       
Traceback for thread 27161 (python3) [] (most recent call last):
    (Python) File "<string>", line 2, in <module>
```

```shell
dan:~/src/pystack (support-missing-process_vm_readv) % pytest
===================================== test session starts =====================================
platform linux -- Python 3.11.2, pytest-8.3.5, pluggy-1.6.0
rootdir: /home/dan/src/pystack
...
=============================== 459 passed, 3 skipped in 15.75s ===============================
```


I also checked what the various errors might look like, say if the file didn't exist
```diff
@@ -273,7 +277,7 @@ ssize_t
 ProcessMemoryManager::readChunkThroughMemFile(remote_addr_t addr, size_t len, char* dst) const
 {
     if (!d_memfile.is_open()) {
-        std::string filepath = "/proc/" + std::to_string(d_pid) + "/mem";
+        std::string filepath = "/proc/" + std::to_string(d_pid) + "/memXXX";
         d_memfile.open(filepath, std::ifstream::binary);
         if (!d_memfile) {
             LOG(ERROR) << "Failed to open file " << filepath;
```

```
dan:~/src/pystack (support-missing-process_vm_readv) % pystack remote $(pgrep python3)
ERROR(process_remote): Failed to open file /proc/27161/memXXX
💀 Engine error: No such file or directory 💀

dan:~/src/pystack (support-missing-process_vm_readv) %
```

Once I was pretty happy that it wasn't too awful, I spun up a flatcar VM and tested the happy path there.

<details><summary>Details (Probably too many) </summary>
<p>

Per https://www.flatcar.org/docs/latest/setup/releases/verify-images/
```shell
curl -L -O https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
gpg --import --keyid-format LONG Flatcar_Image_Signing_Key.asc
```
```shell
cat  << 'EOF' > ssh_config
Host flatcar
HostName localhost
Port 2222
User core
StrictHostKeyChecking no
UserKnownHostsFile /dev/null
EOF
cat << 'EOF' > acquire.sh 
#!/bin/sh

set -eu

#current=4152.2.3
current=current

base_name=flatcar_production_qemu_uefi

for suff in .sh _image.img _efi_code.fd _efi_vars.fd; do
  wget https://lts.release.flatcar-linux.net/arm64-usr/$current/${base_name}${suff}
  wget https://lts.release.flatcar-linux.net/arm64-usr/$current/${base_name}${suff}.sig
  gpg --verify ${base_name}${suff}.sig
done

chmod +x ${base_name}.sh
EOF

sh ./acquire.sh

patch <<'EOF'
diff --git a/flatcar_production_qemu_uefi.sh b/flatcar_production_qemu_uefi.sh
index e97ba31..0e31ba9 100755
--- a/flatcar_production_qemu_uefi.sh
+++ b/flatcar_production_qemu_uefi.sh
@@ -220,6 +220,8 @@ else
             set -- -machine q35 -cpu kvm64 -smp 1 -nographic "$@" ;;
         arm64-usr+aarch64)
             set -- -machine virt,accel=kvm,gic-version=3 -cpu host -smp "${VM_NCPUS}" -nographic "$@" ;;
+        arm64-usr+arm64)
+            set -- -machine virt,accel=hvf -cpu host -smp "${VM_NCPUS}" -nographic "$@" ;;
         arm64-usr+*)
             if test "${VM_NCPUS}" -gt 4 ; then
                 VM_NCPUS=4
EOF
```
```
./flatcar_production_qemu_uefi.sh -nographic
```
```
ssh -F ssh_config flatcar
```

</p>
</details> 

```
core@localhost ~ $ docker run -it --rm python:3.12 bash
Unable to find image 'python:3.12' locally
...
Status: Downloaded newer image for python:3.12
root@946ac0b130f3:/# # fix broken dns
root@946ac0b130f3:/# newresolve=$(sed $'/nameserver/i\\\nnameserver 1.1.1.1' /etc/resolv.conf); echo "$newresolve" > /etc/resolv.conf
root@946ac0b130f3:/# apt-get update && apt-get install libdw-dev libelf-dev pkg-config
...
root@946ac0b130f3:/# python -m pip install "pystack @ git+https://github.com/cakemanny/pystack.git@support-missing-process_vm_readv"
...
root@dce305e0c604:/# pystack
usage: pystack [-h] [-v] [--version] [--no-color] {remote,core} ...
pystack: error: the following arguments are required: command
root@dce305e0c604:/# python3 -c $'import time\nwhile True: time.sleep(1)' &
[1] 260
root@dce305e0c604:/# pystack remote 260
Traceback for thread 260 (python3) [] (most recent call last):
    (Python) File "<string>", line 2, in <module>

root@dce305e0c604:/# pystack remote 260 -vv 2>&1| grep falling
DEBUG(process_remote): process_vm_readv not compiled in kernel, falling back to /proc/PID/mem
root@dce305e0c604:/#
```

**Additional context**
I've not written any C++ for about 14 years, so I've probably missed out on some cleverer or prettier ways of doing this.
