### PR TITLE
add error number to file open error messages

### DIFF
--- a/src/pystack/_pystack/elf_common.cpp
+++ b/src/pystack/_pystack/elf_common.cpp
@@ -562,7 +562,6 @@ getBuildId(const std::string& filename)
         LOG(ERROR) << "Cannot open ELF file " << filename << " (" << std::strerror(errno) << ")";
         return "";
     }
-
     const int fd = fileno(file.get());
 
     elf_unique_ptr elf = elf_unique_ptr(elf_begin(fd, ELF_C_READ_MMAP, nullptr), elf_end);


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
As per https://github.com/bloomberg/pystack/pull/233, I have added more detail to error message when file open has failed in several locations.

I have had to debug an issue in https://github.com/mantidproject/mantid where core dump analysis was failing due to many `ERROR(process_core): Cannot open ELF file`. The ultimate cause was the maximum number of open file descriptors in the process being exceeded. Having this error message initially would have made identifying the issue trivial.

Example old output: `ERROR(process_core): Cannot open ELF file /lib/x86_64-linux-gnu/libpthread.so.0`
New output: `ERROR(process_core): Cannot open ELF file /lib/x86_64-linux-gnu/libpthread.so.0 (Too many open files)`

**Testing performed**
Have run `pystack core <core_dump_file>` and observed new errors.

