### PR TITLE
ci: Switch to Trusted Publishing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -413,6 +413,8 @@ jobs:
     needs: [test_wheels]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write # Required to retrieve a Trusted Publishing token
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -426,4 +428,3 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip_existing: true
-          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Stop using long-lived secrets for PyPI publishing.