### PR TITLE
Fix security-related issues in github actions flagged by zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,5 +1,7 @@
 name: Wheels
 
+permissions: {}
+
 on:
   push:
   pull_request:
@@ -19,12 +21,14 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -59,19 +63,19 @@ jobs:
       - name: Disable ptrace security restrictions
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sdist
       - name: Extract sdist
         run: |
           tar zxvf *.tar.gz --strip-components=1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         env:
           CIBW_BUILD: "cp3{9..14}{t,}-${{ matrix.wheel_type }}"
           CIBW_ARCHS_LINUX: auto
           CIBW_ENABLE: cpython-prerelease cpython-freethreading
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.wheel_type }}-wheels
           path: ./wheelhouse/*.whl
@@ -84,13 +88,15 @@ jobs:
       matrix:
         python_version: ["2.7", "3.7"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '>=3.13'
       - name: Set up dependencies
@@ -124,17 +130,20 @@ jobs:
       matrix:
         python_version: ["3.13"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: latest
           python-version: ${{ matrix.python_version }}
           activate-environment: true
+          enable-cache: false
       - name: Set up dependencies
         run: |
           sudo apt-get update
@@ -159,12 +168,14 @@ jobs:
       matrix:
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{matrix.python_version}}-dev"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
@@ -194,12 +205,14 @@ jobs:
       matrix:
         python_version: ["3.9", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{matrix.python_version}}-dev"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_aarch64-wheels"
           path: dist
@@ -232,12 +245,14 @@ jobs:
       matrix:
         python_version: ["3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{matrix.python_version}}-dev"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
@@ -274,15 +289,17 @@ jobs:
       fail-fast: false
 
     container:
-      image: alpine
+      image: alpine@4d889c14e7d5
       options: --cap-add=SYS_PTRACE
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up dependencies
         run: |
           apk add --update alpine-sdk bash alpine-sdk python3 python3-dev gdb musl-dbg python3-dbg
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "musllinux_x86_64-wheels"
           path: dist
@@ -304,11 +321,13 @@ jobs:
       fail-fast: false
 
     container:
-      image: fedora
+      image: fedora@f717d3f59ea0
       options: --cap-add=SYS_PTRACE
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up dependencies
         run: |
           dnf install -y \
@@ -319,7 +338,7 @@ jobs:
             python3-devel
           dnf debuginfo-install -y \
             python3
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
@@ -340,10 +359,12 @@ jobs:
       fail-fast: false
 
     container:
-      image: archlinux
+      image: archlinux@32c78c548c1a
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up dependencies
         run: |
           pacman -Syu --noconfirm \
@@ -356,7 +377,7 @@ jobs:
             python-wheel \
             elfutils \
             debuginfod
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
@@ -379,11 +400,13 @@ jobs:
       fail-fast: false
 
     container:
-      image: debian
+      image: debian@de6a8f94c0e8
       options: --cap-add=SYS_PTRACE
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up dependencies
         run: |
           apt-get update
@@ -394,7 +417,7 @@ jobs:
             python3-pip \
             python3-venv \
             python3-dbg
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: "manylinux_x86_64-wheels"
           path: dist
@@ -416,7 +439,7 @@ jobs:
     permissions:
       id-token: write # Required to retrieve a Trusted Publishing token
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           # with no name set, it downloads all of the artifacts
           path: dist
@@ -425,6 +448,6 @@ jobs:
           mv dist/*-wheels/*.whl dist/
           rmdir dist/{sdist,*-wheels}
           ls -R dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip_existing: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -289,7 +289,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: alpine:3.22.4
+      image: alpine
       options: --cap-add=SYS_PTRACE
 
     steps:
@@ -321,7 +321,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: fedora:45
+      image: fedora
       options: --cap-add=SYS_PTRACE
 
     steps:
@@ -359,7 +359,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: archlinux:base-devel-20260517.0.530531
+      image: archlinux
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -400,7 +400,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: debian:stable
+      image: debian
       options: --cap-add=SYS_PTRACE
 
     steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -138,7 +138,7 @@ jobs:
           name: "manylinux_x86_64-wheels"
           path: dist
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: latest
           python-version: ${{ matrix.python_version }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -289,7 +289,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: alpine@4d889c14e7d5
+      image: alpine:3.22.4
       options: --cap-add=SYS_PTRACE
 
     steps:
@@ -321,7 +321,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: fedora@f717d3f59ea0
+      image: fedora:45
       options: --cap-add=SYS_PTRACE
 
     steps:
@@ -359,7 +359,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: archlinux@32c78c548c1a
+      image: archlinux:base-devel-20260517.0.530531
       options: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -400,7 +400,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: debian@de6a8f94c0e8
+      image: debian:stable
       options: --cap-add=SYS_PTRACE
 
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,13 +69,13 @@ jobs:
           lcov --capture --directory build --output-file cppcoverage.lcov
           lcov --extract cppcoverage.lcov '*/src/pystack/_pystack/*' --output-file cppcoverage.lcov
       - name: Upload Python report to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: pycoverage.lcov
           flags: python
       - name: Upload C++ report to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cppcoverage.lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,13 +69,13 @@ jobs:
           lcov --capture --directory build --output-file cppcoverage.lcov
           lcov --extract cppcoverage.lcov '*/src/pystack/_pystack/*' --output-file cppcoverage.lcov
       - name: Upload Python report to Codecov
-        uses: codecov/codecov-action
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: pycoverage.lcov
           flags: python
       - name: Upload C++ report to Codecov
-        uses: codecov/codecov-action
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cppcoverage.lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,9 +27,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: Set up dependencies
@@ -67,13 +69,13 @@ jobs:
           lcov --capture --directory build --output-file cppcoverage.lcov
           lcov --extract cppcoverage.lcov '*/src/pystack/_pystack/*' --output-file cppcoverage.lcov
       - name: Upload Python report to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: pycoverage.lcov
           flags: python
       - name: Upload C++ report to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cppcoverage.lcov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 name: Publish docs
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -13,9 +15,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: Set up dependencies
@@ -32,7 +36,7 @@ jobs:
         run: |
           make docs
       - name: Publish docs to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           folder: docs/_build/html
           single-commit: true

--- a/.github/workflows/lint_and_docs.yml
+++ b/.github/workflows/lint_and_docs.yml
@@ -1,13 +1,17 @@
 name: Lint and docs
 
+permissions: {}
+
 on: [push, pull_request]
 
 jobs:
   lint_and_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: Set up dependencies
@@ -23,7 +27,8 @@ jobs:
       - name: Lint sources
         run: |
           make lint PYTHON=python3
-          python3 -m prek run --all-files --hook-stage pre-push
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       - name: Build docs
         run: |
           towncrier build --version 99.99 --name pystack --keep

--- a/.github/workflows/news-check.yml
+++ b/.github/workflows/news-check.yml
@@ -1,4 +1,7 @@
 name: News entry check
+
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -16,7 +19,7 @@ jobs:
     name: Check for news entry
     steps:
       - name: "Check for news entry"
-        uses: brettcannon/check-for-changed-files@v1
+        uses: brettcannon/check-for-changed-files@871d7b8b5917a4f6f06662e2262e8ffc51dff6d1 # v1
         with:
           file-pattern: |
             news/*.rst

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,4 +1,7 @@
 name: Sanity check
+
+permissions: {}
+
 on:
   pull_request:
     types:
@@ -15,10 +18,10 @@ jobs:
     steps:
       - name: Get PR Commits
         id: "get-pr-commits"
-        uses: tim-actions/get-pr-commits@master
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@master
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # master
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 # Stage 2: Final stage
 FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
+LABEL org.opencontainers.image.source="https://github.com/bloomberg/pystack"
 
 # Install runtime dependencies
 RUN apt-get update \

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -4,3 +4,8 @@ rules:
       # Only exposes the codecov token; low risk
       - coverage.yml:74
       - coverage.yml:80
+  unpinned-images:
+      - build_wheels.yml:292
+      - build_wheels.yml:324
+      - build_wheels.yml:362
+      - build_wheels.yml:403

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  secrets-outside-env:
+    ignore:
+      # Only exposes the codecov token; low risk
+      - coverage.yml:74
+      - coverage.yml:80

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -5,6 +5,7 @@ rules:
       - coverage.yml:74
       - coverage.yml:80
   unpinned-images:
+    ignore:
       - build_wheels.yml:292
       - build_wheels.yml:324
       - build_wheels.yml:362


### PR DESCRIPTION
**Issue number of the reported bug or feature request:** Closes #287.

**Describe your changes**
This PR addresses a number of security-related issues in the github actions (and dependabot config) that were flagged by zizmor. Most of the changes are:

- Pinning action versions to commit hashes
- Disable persisting credentials in workflows after checkout
- The default permissions are now set as conservatively as possible

This PR also adds a zizmor action to ensure these issues don't arise in the future.

Note that the container images used during the wheel builds workflow remain unpinned. After weighing the dangers of running a compromised container here, it was decided that the effort of keeping pinned containers up to date was not worth the effort. As a result we have zizmor configured to ignore these rule violations here.

**Testing performed**
This will be tested by running the CI in this PR.