### PR TITLE
Solve #290: Fix extra blank line in pystack output 

### DIFF
--- a/src/pystack/traceback_formatter.py
+++ b/src/pystack/traceback_formatter.py
@@ -35,7 +35,7 @@ def format_frame(frame: PyFrame) -> Iterable[str]:
             if line_end != line_start:
                 col_end = len(source)
             a = source[:col_start]
-            b = source[col_start:col_end]
+            b = source[col_start:col_end].strip("\n")
             c = source[col_end:]
             final = f'{a}{colored(b, color="blue")}{c}'
             yield f"        {final.strip()}"


### PR DESCRIPTION
Signed-off-by: haswee <hasweebanoth@gmail.com>

*Issue number of the reported bug or feature request: https://github.com/bloomberg/pystack/issues/290 *

**Describe your changes**
https://github.com/bloomberg/pystack/blob/debc9e8a0ea0743f38cf15c044d8704374964b77/src/pystack/traceback_formatter.py#L41 tries to strip the colored cell which fails to remove newline character in b.

**Testing performed**
Before the change: 
```
root@codespaces-0213cb:/workspaces/pystack# pystack core core.4308 
Using executable found in the core file: /venv/bin/python

Core file information:
state: t zombie: True niceness: 0
pid: 4308 ppid: 4096 sid: 4096
uid: 0 gid: 0 pgrp: 4308
executable: python arguments: python

The process died due receiving signal SIGSTOP
Traceback for thread 4308 (python) [] (most recent call last):
    (Python) File "<frozen runpy>", line 198, in _run_module_as_main
    (Python) File "<frozen runpy>", line 88, in _run_code
    (Python) File "/usr/lib/python3.12/http/server.py", line 1329, in <module>
        test(

    (Python) File "/usr/lib/python3.12/http/server.py", line 1284, in test
        httpd.serve_forever()
    (Python) File "/usr/lib/python3.12/socketserver.py", line 235, in serve_forever
        ready = selector.select(poll_interval)
    (Python) File "/usr/lib/python3.12/selectors.py", line 415, in select
        fd_event_list = self._selector.poll(timeout)
```
After the change:
```
root@codespaces-0213cb:/workspaces/pystack# pystack core core.4308 
Using executable found in the core file: /venv/bin/python

Core file information:
state: t zombie: True niceness: 0
pid: 4308 ppid: 4096 sid: 4096
uid: 0 gid: 0 pgrp: 4308
executable: python arguments: python

The process died due receiving signal SIGSTOP
Traceback for thread 4308 (python) [] (most recent call last):
    (Python) File "<frozen runpy>", line 198, in _run_module_as_main
    (Python) File "<frozen runpy>", line 88, in _run_code
    (Python) File "/usr/lib/python3.12/http/server.py", line 1329, in <module>
        test(
    (Python) File "/usr/lib/python3.12/http/server.py", line 1284, in test
        httpd.serve_forever()
    (Python) File "/usr/lib/python3.12/socketserver.py", line 235, in serve_forever
        ready = selector.select(poll_interval)
    (Python) File "/usr/lib/python3.12/selectors.py", line 415, in select
        fd_event_list = self._selector.poll(timeout)

```

**Additional context**
Add any other context about your contribution here.
