### PR TITLE
Exit with a clear message when ptrace_scope blocks the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -6,3 +8,21 @@ import pytest
 def pytest_sessionstart(session):
     if not shutil.which("gcore"):
         pytest.exit("gcore not found (you probably forgot to install gdb)")
+
+    # A restrictive Yama ptrace_scope stops pystack from attaching to a
+    # running process, so the integration tests hang instead of failing
+    # with a useful message.
+    ptrace_scope_path = "/proc/sys/kernel/yama/ptrace_scope"
+    try:
+        if os.getuid() == 0:
+            ptrace_scope = "0"
+        else:
+            ptrace_scope = Path(ptrace_scope_path).read_text().strip()
+    except OSError:
+        ptrace_scope = "0"
+    if ptrace_scope != "0":
+        pytest.exit(
+            f"ptrace_scope is {ptrace_scope}; pystack cannot attach to a running "
+            "process and the tests will hang. Run "
+            "'sudo sysctl kernel.yama.ptrace_scope=0' and try again."
+        )


### PR DESCRIPTION
Closes #307.

When Yama's `ptrace_scope` is set to anything other than `0`, pystack can't attach to a running process, so the integration tests hang instead of failing with a useful message.

`tests/conftest.py` already does a `pytest_sessionstart` preflight for `gcore`, so I added a `ptrace_scope` check right next to it: read `/proc/sys/kernel/yama/ptrace_scope`, and if it's non-zero, `pytest.exit` with the command to fix it (`sudo sysctl kernel.yama.ptrace_scope=0`).

The read is wrapped in `try/except OSError`, so on a system where that file doesn't exist (non-Linux, or a kernel built without Yama) the check is just a no-op.