### PR TITLE
Update elfutils version and use ubuntu apt packages in dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Once the codespace is ready, all dependencies will be installed and hooks
 will be configured automatically.
 
 Note that the dev container is built from the project's `Dockerfile`, which
-compiles `elfutils` from source, so the first build takes a few minutes.
+uses the distribution-provided `libdw` and `libelf` development packages.
 
 pystack requires elevated ptrace permissions to inspect processes — the dev
 container already handles this via `--cap-add=SYS_PTRACE` and

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,4 @@
-# Stage 1: Elfutils build stage
-FROM ubuntu:26.04 AS elfutils_builder
-ARG DEBIAN_FRONTEND=noninteractive
-ENV VERS=0.193
-
-# Install elfutils build dependencies
-RUN apt-get update \
-    && apt-get install -y --force-yes --no-install-recommends software-properties-common gpg-agent \
-        build-essential \
-        libzstd-dev \
-        ca-certificates \
-        curl \
-        lsb-release \
-        bzip2 \
-        zlib1g-dev \
-        zlib1g-dev:native \
-        libbz2-dev \
-        liblzma-dev \
-        gettext \
-        po-debconf \
-        gawk \
-        libc6-dbg \
-        flex \
-        bison \
-        pkg-config \
-        libarchive-dev \
-        libcurl4-gnutls-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /elfutils \
-    && cd /elfutils \
-    && curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2 \
-    && tar -xf elfutils.tar.bz2 --strip-components 1 \
-    && CFLAGS='-Wno-error -g -O3' CXXFLAGS='-Wno-error -g -O3' ./configure --disable-nls --enable-libdebuginfod=dummy --disable-debuginfod --with-zstd \
-    && make install
-
-# Stage 2: Final stage
+# Build stage
 FROM ubuntu:26.04
 ARG DEBIAN_FRONTEND=noninteractive
 LABEL org.opencontainers.image.source="https://github.com/bloomberg/pystack"
@@ -57,11 +21,10 @@ RUN apt-get update \
     liblzma-dev \
     libbz2-dev \
     zlib1g-dev \
+    libdw-dev \
+    libelf-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /etc/debuginfod/*.urls
-
-# Copy the installed files from the elfutils_builder stage
-COPY --from=elfutils_builder /usr/local /usr/local
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -70,8 +33,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV VIRTUAL_ENV="/venv" \
     PATH="/venv/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin" \
     PYTHONDONTWRITEBYTECODE=1 \
-    TZ=UTC \
-    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+    TZ=UTC
 
 # Install Python interpreters via uv, and install setuptools for each
 RUN uv_versions="3.8 3.9 3.10 3.11 3.12 3.13 3.14 3.15" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,13 +121,14 @@ skip = "*-musllinux_aarch64"
 [tool.cibuildwheel.linux]
 before-all = [
   "yum install -y libzstd-devel cmake",
+  "yum install -y devtoolset-10-make || true",  # Install a new enough GNU make on manylinux2014
   "cd /",
   "VERS=0.195",
   "curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xf elfutils.tar.bz2",
   "cd elfutils-$VERS",
   "CFLAGS='-Wno-error -g -O3' CXXFLAGS='-Wno-error -g -O3' ./configure --disable-nls --enable-libdebuginfod=dummy --disable-debuginfod --with-zstd",
-  "make install"
+  'PATH="/opt/rh/devtoolset-10/root/usr/bin/:$PATH" make install',  # Ensure we pick up gnu make 4.x on manylinux2014
 ]
 
 # Override the default linux before-all for musl linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ skip = "*-musllinux_aarch64"
 before-all = [
   "yum install -y libzstd-devel cmake",
   "cd /",
-  "VERS=0.193",
+  "VERS=0.195",
   "curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xf elfutils.tar.bz2",
   "cd elfutils-$VERS",
@@ -144,7 +144,7 @@ before-all = [
   # https://git.alpinelinux.org/aports/tree/main/elfutils/musl-macros.patch
   "cd /",
   "apk add --update argp-standalone bison bsd-compat-headers bzip2-dev flex-dev libtool linux-headers musl-fts-dev musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev cmake",
-  "VERS=0.193",
+  "VERS=0.195",
   "curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xf elfutils.tar.bz2",
   "cd elfutils-$VERS",


### PR DESCRIPTION
Issue number of the reported bug or feature request: fixes #314 

**Describe your changes**
Replace the custom `elfutils` build stage in the Dockerfile with Ubuntu's packaged `libdw-dev` and `libelf-dev` dependencies.

Removed the `elfutils_builder` stage from the Dockerfile
Removed the download and compilation of elfutils 0.193
Added `libdw-dev` and `libelf-dev` to the Ubuntu package list
Removed the copy step that imported the custom-built libraries
Updated documentation referencing the source build of elfutils

**Testing performed**
Successfully built the Docker image
Verified `pkg-config` detects both `libdw` and `libelf`
Successfully built and installed pystack inside the container using the distro-provided libraries

**Additional context**
`Ubuntu 26.04` currently provides `elfutils/libdw` version `0.194` rather than `0.195`
