### PR TITLE
ci: Pin cp313t wheel builds to cibuildwheel v3

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -100,8 +100,12 @@ jobs:
       - name: Extract sdist
         run: |
           tar zxvf *.tar.gz --strip-components=1
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install cibuildwheel v3
+        run: python -m pip install 'cibuildwheel<4'
       - name: Build wheels
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        run: python -m cibuildwheel
         env:
           CIBW_BUILD: "cp313t-${{ matrix.wheel_type }}"
           CIBW_ARCHS_LINUX: auto


### PR DESCRIPTION
cibuildwheel v4 drops support for building 3.13t wheels. Switching from using the pypa/cibuildwheel action to using `pip install` will let us express the version constraint for this job and stop dependabot from trying to update it to a version that can't work.
