### PR TITLE
ci: Tag stable abi wheels as abi3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,11 @@ install.strip = false
 wheel.packages = ["src/pystack"]
 wheel.install-dir = "pystack"
 wheel.exclude = ["pystack/_pystack/**"]
+# Build against the CPython Limited API / stable ABI so that CPython >= 3.12
+# non-free-threaded builds produce a single cp312-abi3 wheel. scikit-build-core
+# automatically ignores this for older Pythons (< 3.12) and for free-threaded
+# interpreters, which continue to produce version-specific wheels.
+wheel.py-api = "cp312"
 metadata.version.provider = "scikit_build_core.metadata.regex"
 metadata.version.input = "src/pystack/_version.py"
 sdist.include = ["src/pystack/_version.py"]


### PR DESCRIPTION
We've been limiting ourselves to the stable ABI for Python 3.12+, but we haven't been tagging those stable ABI wheels as `abi3`.

Fix this, allowing the wheels built for Python 3.12 to be used for 3.13, 3.14, and 3.15 as well.

Note that nanobind does not yet support `abi3t`, so free-threaded wheels are still built per-version.