### PR TITLE
Update for 3.15.0b4

### DIFF
--- a/src/pystack/_pystack/cpython/runtime.h
+++ b/src/pystack/_pystack/cpython/runtime.h
@@ -669,6 +669,7 @@ typedef struct _Py_DebugOffsets
         uint64_t current_frame;
         uint64_t base_frame;
         uint64_t last_profiled_frame;
+        uint64_t last_profiled_frame_seq;  // Added in 3.15.0b4
         uint64_t thread_id;
         uint64_t native_thread_id;
         uint64_t datastack_chunk;


### PR DESCRIPTION
An ABI-breaking change was introduced in Python 3.15.0b4 that changed the layout of the `_Py_DebugOffsets` structure. Update to require the new layout.
