### PR TITLE
Support signal frame unwinding on AArch64

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: "^[.]bumpversion[.]cfg"
+        exclude_types: [diff]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # frozen: v1.10.0

--- a/build_scripts/elfutils-aarch64-signal-frame.patch
+++ b/build_scripts/elfutils-aarch64-signal-frame.patch
@@ -1,0 +1,100 @@
+This patch allows elfutils to unwind through AArch64 signal frames on Linux.
+
+diff --git a/backends/aarch64_unwind.c b/backends/aarch64_unwind.c
+index e0a7e96..d276d92 100644
+--- a/backends/aarch64_unwind.c
++++ b/backends/aarch64_unwind.c
+@@ -40,16 +40,91 @@
+ 
+ #include "libebl_CPU.h"
+ 
++/* Linux AArch64 rt_sigreturn ABI.  See kernel/vdso/sigreturn.S,
++   kernel/signal.c and include/uapi/asm/{ucontext,sigcontext}.h under:
++   https://github.com/torvalds/linux/tree/v6.6/arch/arm64
++
++   mov x8, #139 (0xd2801168) followed by svc #0 (0xd4000001) forms
++   RT_SIGRETURN_WORD on little-endian systems.  The frame offsets are:
++
++     mcontext = 128 + 8 + 8 + 24 + 128 + 8 = 0x130
++     regs = 8, sp = 8 + 31 * 8 = 0x100, pc = sp + 8 = 0x108.
++ */
++#define RT_SIGRETURN_WORD UINT64_C (0xd4000001d2801168)
++#define RT_SIGFRAME_SIGCONTEXT_OFFSET 0x130
++#define SIGCONTEXT_REGS_OFFSET 0x8
++#define SIGCONTEXT_SP_OFFSET 0x100
++#define SIGCONTEXT_PC_OFFSET 0x108
++
++static bool
++unwind_signal_frame (Ebl *ebl, Dwarf_Addr pc,
++		     ebl_tid_registers_t *setfunc,
++		     ebl_tid_registers_get_t *getfunc,
++		     ebl_pid_memory_read_t *readfunc, void *arg,
++		     bool *signal_framep)
++{
++  /* Do not guess at the Linux AArch64 big-endian signal ABI here.  */
++  if (ebl->data != ELFDATA2LSB)
++    return false;
++
++  /* frame_unwind.c normally passes PC - 1 for a non-activation frame.  */
++  if ((pc & 3) == 3)
++    ++pc;
++  else if ((pc & 3) != 0)
++    return false;
++
++  Dwarf_Word instructions;
++  if (!readfunc (pc, &instructions, arg)
++      || instructions != RT_SIGRETURN_WORD)
++    return false;
++
++  Dwarf_Word signal_sp;
++  if (!getfunc (SP_REG, 1, &signal_sp, arg))
++    return false;
++
++  const Dwarf_Addr sigcontext
++    = signal_sp + RT_SIGFRAME_SIGCONTEXT_OFFSET;
++  Dwarf_Word registers[31];
++  Dwarf_Word saved_sp;
++  Dwarf_Word saved_pc;
++
++  /* Read the whole context before changing the tentative caller state.  */
++  for (unsigned int regno = 0; regno < 31; ++regno)
++    if (!readfunc (sigcontext + SIGCONTEXT_REGS_OFFSET
++		       + regno * sizeof (Dwarf_Word),
++		       &registers[regno], arg))
++      return false;
++
++  if (!readfunc (sigcontext + SIGCONTEXT_SP_OFFSET, &saved_sp, arg)
++      || !readfunc (sigcontext + SIGCONTEXT_PC_OFFSET, &saved_pc, arg)
++      || saved_pc == 0
++      || saved_sp == 0
++      || (saved_sp & 15) != 0)
++    return false;
++
++  if (!setfunc (0, 31, registers, arg)
++      || !setfunc (SP_REG, 1, &saved_sp, arg)
++      || !setfunc (-1, 1, &saved_pc, arg))
++    return false;
++
++  *signal_framep = true;
++  return true;
++}
++
+ /* There was no CFI. Maybe we happen to have a frame pointer and can unwind from that?  */
+ 
+ bool
+-EBLHOOK(unwind) (Ebl *ebl __attribute__ ((unused)), Dwarf_Addr pc __attribute__ ((unused)),
++EBLHOOK(unwind) (Ebl *ebl, Dwarf_Addr pc,
+                  ebl_tid_registers_t *setfunc, ebl_tid_registers_get_t *getfunc,
+                  ebl_pid_memory_read_t *readfunc, void *arg,
+-                 bool *signal_framep __attribute__ ((unused)))
++                 bool *signal_framep)
+ {
+   Dwarf_Word fp, lr, sp;
+ 
++  if (unwind_signal_frame (ebl, pc, setfunc, getfunc, readfunc, arg,
++			   signal_framep))
++    return true;
++
+   if (!getfunc(LR_REG, 1, &lr, arg))
+     return false;
+ 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,13 +133,14 @@ skip = "*-musllinux_aarch64"
 
 [tool.cibuildwheel.linux]
 before-all = [
-  "yum install -y libzstd-devel cmake",
+  "yum install -y libzstd-devel cmake patch",
   "yum install -y devtoolset-10-make || true",  # Install a new enough GNU make on manylinux2014
   "cd /",
   "VERS=0.195",
   "curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xf elfutils.tar.bz2",
   "cd elfutils-$VERS",
+  "patch --batch --forward --fuzz=0 -p1 -i {package}/build_scripts/elfutils-aarch64-signal-frame.patch",
   "CFLAGS='-Wno-error -g -O3' CXXFLAGS='-Wno-error -g -O3' ./configure --disable-nls --enable-libdebuginfod=dummy --disable-debuginfod --with-zstd",
   'PATH="/opt/rh/devtoolset-10/root/usr/bin/:$PATH" make install',  # Ensure we pick up gnu make 4.x on manylinux2014
 ]
@@ -157,11 +158,12 @@ before-all = [
   # set the FNM_EXTMATCH macro to get the build to succeed is seen here:
   # https://git.alpinelinux.org/aports/tree/main/elfutils/musl-macros.patch
   "cd /",
-  "apk add --update argp-standalone bison bsd-compat-headers bzip2-dev flex-dev libtool linux-headers musl-fts-dev musl-libintl musl-obstack-dev xz-dev zlib-dev zstd-dev cmake",
+  "apk add --update argp-standalone bison bsd-compat-headers bzip2-dev flex-dev libtool linux-headers musl-fts-dev musl-libintl musl-obstack-dev patch xz-dev zlib-dev zstd-dev cmake",
   "VERS=0.195",
   "curl https://sourceware.org/elfutils/ftp/$VERS/elfutils-$VERS.tar.bz2 > ./elfutils.tar.bz2",
   "tar -xf elfutils.tar.bz2",
   "cd elfutils-$VERS",
+  "patch --batch --forward --fuzz=0 -p1 -i {package}/build_scripts/elfutils-aarch64-signal-frame.patch",
   "CFLAGS='-Wno-error -DFNM_EXTMATCH=0 -g -O3' CXXFLAGS='-Wno-error -g -O3' ./configure --disable-nls --enable-libdebuginfod=dummy --disable-debuginfod --with-zstd",
   "make install",
 

--- a/tests/integration/test_gather_stacks.py
+++ b/tests/integration/test_gather_stacks.py
@@ -3,13 +3,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from pystack.engine import NativeReportingMode
 from pystack.engine import get_process_threads
+from pystack.engine import get_process_threads_for_core
 from pystack.types import LocationInfo
 from pystack.types import NativeFrame
 from pystack.types import frame_type
 from tests.utils import ALL_PYTHONS
+from tests.utils import AVAILABLE_PYTHONS
 from tests.utils import all_pystack_combinations
+from tests.utils import generate_core_file
 from tests.utils import python_has_inlined_eval_frames
 from tests.utils import python_has_position_information
 from tests.utils import spawn_child_process
@@ -26,6 +31,7 @@ TEST_POSITION_INFO_FILE = Path(__file__).parent / "position_information_program.
 TEST_NO_FRAMES_AT_SHUTDOWN_FILE = (
     Path(__file__).parent / "no_frames_at_shutdown_program.py"
 )
+TEST_SIGNAL_HANDLER_EXTENSION = Path(__file__).parent / "testext"
 
 
 @all_pystack_combinations()
@@ -303,6 +309,110 @@ def test_multiple_thread_stack_native(python, method, blocking, tmpdir):
         else:  # pragma: no cover
             assert all(frame.linenumber != 0 for frame in eval_frames)
             assert any(frame.path and "?" not in frame.path for frame in eval_frames)
+
+
+def build_signal_handler_extension(python_executable, tmpdir):
+    """Build the testext extension in tmpdir and return its driver script."""
+    extension_path = tmpdir / "testext"
+    shutil.copytree(TEST_SIGNAL_HANDLER_EXTENSION, extension_path)
+    subprocess.run(
+        [python_executable, str(extension_path / "setup.py"), "build_ext", "--inplace"],
+        check=True,
+        cwd=extension_path,
+        capture_output=True,
+    )
+    return extension_path / "main.py"
+
+
+def assert_stack_was_unwound_through_signal_frame(thread, program):
+    """Ensure we got the expected Python stack and the right number of eval frames."""
+    frames = list(thread.frames)
+
+    filenames = {frame.code.filename for frame in frames}
+    assert filenames == {str(program)}
+
+    functions = [frame.code.scope for frame in frames]
+    assert functions == ["<module>", "first_func", "second_func", "third_func"]
+
+    native_frames = list(thread.native_frames)
+    assert native_frames
+
+    eval_frames = [
+        frame
+        for frame in native_frames
+        if frame_type(frame, thread.python_version) == NativeFrame.FrameType.EVAL
+    ]
+    assert eval_frames
+    assert len(eval_frames) == sum(frame.is_entry for frame in thread.frames)
+    assert all("?" not in frame.symbol for frame in eval_frames)
+
+
+ALL_PYTHONS_BUT_XFAIL_ON_ALPINE = pytest.mark.parametrize(
+    "python",
+    [
+        pytest.param(
+            python[:2],
+            marks=(
+                pytest.mark.xfail(
+                    python.uses_musl,
+                    reason="unwinding through signal frames fails on x86-64 Alpine",
+                )
+            ),
+        )
+        for python in AVAILABLE_PYTHONS
+    ],
+    ids=[python[1].name for python in AVAILABLE_PYTHONS],
+)
+
+
+@ALL_PYTHONS_BUT_XFAIL_ON_ALPINE
+def test_stack_of_thread_in_signal_handler(python, tmpdir):
+    # GIVEN
+
+    _, python_executable = python
+
+    # WHEN
+
+    program = build_signal_handler_extension(python_executable, tmpdir)
+    with spawn_child_process(python_executable, program, tmpdir) as child_process:
+        threads = list(
+            get_process_threads(
+                child_process.pid,
+                stop_process=True,
+                native_mode=NativeReportingMode.PYTHON,
+            )
+        )
+
+    # THEN
+
+    assert len(threads) == 1
+    (thread,) = threads
+    assert_stack_was_unwound_through_signal_frame(thread, program)
+
+
+@ALL_PYTHONS_BUT_XFAIL_ON_ALPINE
+def test_stack_of_thread_in_signal_handler_for_core(python, tmpdir):
+    # GIVEN
+
+    _, python_executable = python
+
+    # WHEN
+
+    program = build_signal_handler_extension(python_executable, tmpdir)
+    with generate_core_file(python_executable, program, tmpdir) as core_file:
+        threads = list(
+            get_process_threads_for_core(
+                core_file,
+                Path(python_executable),
+                native_mode=NativeReportingMode.PYTHON,
+            )
+        )
+
+    # THEN
+
+    assert len(threads) == 1
+    (thread,) = threads
+    assert_stack_was_unwound_through_signal_frame(thread, program)
 
 
 @ALL_PYTHONS

--- a/tests/integration/testext/main.py
+++ b/tests/integration/testext/main.py
@@ -1,0 +1,19 @@
+import sys
+
+import testext
+
+
+def first_func():
+    second_func()
+
+
+def second_func():
+    third_func()
+
+
+def third_func():
+    # Blocks forever inside a C signal handler, after announcing we're ready.
+    testext.signal_readiness_then_block(sys.argv[1])
+
+
+first_func()

--- a/tests/integration/testext/setup.py
+++ b/tests/integration/testext/setup.py
@@ -1,0 +1,23 @@
+import os
+
+try:
+    from distutils.core import Extension
+    from distutils.core import setup
+except ImportError:
+    from setuptools import Extension  # type: ignore[no-redef]
+    from setuptools import setup  # type: ignore[no-redef]
+
+ROOT = os.path.realpath(os.path.dirname(__file__))
+
+setup(
+    name="testext",
+    version="0.0",
+    ext_modules=[
+        Extension(
+            "testext",
+            language="c++",
+            sources=[os.path.join(ROOT, "testext.cpp")],
+        ),
+    ],
+    zip_safe=False,
+)

--- a/tests/integration/testext/testext.cpp
+++ b/tests/integration/testext/testext.cpp
@@ -1,0 +1,90 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+
+static int fifo_fd = -1;
+
+void
+writeAll(const char* buf, size_t len)
+{
+    while (len > 0) {
+        ssize_t written = write(fifo_fd, buf, len);
+        if (written <= 0) {
+            if (written < 0 && errno == EINTR) {
+                continue;
+            }
+            Py_FatalError(strerror(errno));
+        }
+        buf += written;
+        len -= (size_t)written;
+    }
+}
+
+// Announce that we're ready and then block forever.
+extern "C" void
+signalReadinessThenBlock(int)
+{
+    const char token[] = "ready";
+    writeAll(token, sizeof(token) - 1);
+    close(fifo_fd);  // Caller reads til EOF, so the FIFO must be closed.
+    pause();
+}
+
+PyObject*
+signal_readiness_then_block(PyObject*, PyObject* args)
+{
+    const char* path;
+    if (!PyArg_ParseTuple(args, "s", &path)) {
+        return NULL;
+    }
+
+    fifo_fd = open(path, O_WRONLY);
+    if (fifo_fd < 0) {
+        return PyErr_SetFromErrno(PyExc_OSError);
+    }
+
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = &signalReadinessThenBlock;
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGUSR1, &action, NULL) != 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    raise(SIGUSR1);
+    Py_FatalError("the signal handler unexpectedly returned");
+}
+
+static PyMethodDef methods[] = {
+        {"signal_readiness_then_block",
+         signal_readiness_then_block,
+         METH_VARARGS,
+         "Write \"ready\" to a FIFO from a signal handler, then block forever"},
+        {NULL, NULL, 0, NULL},
+};
+
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT, "testext", "", -1, methods};
+
+PyMODINIT_FUNC
+PyInit_testext(void)
+{
+    PyObject* mod = PyModule_Create(&moduledef);
+#    ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#    endif
+    return mod;
+}
+#else
+PyMODINIT_FUNC
+inittestext(void)
+{
+    Py_InitModule("testext", methods);
+}
+#endif

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,7 +39,9 @@ ALL_VERSIONS = [
     ((2, 7), "python2.7"),
 ]
 
-Interpreter = collections.namedtuple("Interpreter", "version path has_symbols")
+Interpreter = collections.namedtuple(
+    "Interpreter", "version path has_symbols uses_musl"
+)
 
 
 def find_all_available_pythons() -> Iterable[Interpreter]:  # pragma: no cover
@@ -79,8 +81,8 @@ def find_all_available_pythons() -> Iterable[Interpreter]:  # pragma: no cover
         has_symbols = result.returncode == 0 and (
             b" stripped" not in result.stdout or b"not stripped" in result.stdout
         )
-
-        yield Interpreter(version, pathlib.Path(location), has_symbols)
+        uses_musl = b"musl" in result.stdout
+        yield Interpreter(version, pathlib.Path(location), has_symbols, uses_musl)
 
 
 AVAILABLE_PYTHONS = tuple(find_all_available_pythons())


### PR DESCRIPTION
#341 

**Describe your changes**
add patch for elfutils to unwind signal frame on aarch64

**Testing performed**
run test in issue and see
```
    (C) File "./Modules/clinic/posixmodule.c.h", line 5649, in os_kill.lto_priv.0 (/usr/local/python3.14t/lib/libpython3.14t.so.1.0)
    (C) File "./Modules/posixmodule.c", line 9666, in os_kill_impl (inlined) (/usr/local/python3.14t/lib/libpython3.14t.so.1.0)
    (C) File "../sysdeps/unix/syscall-template.S", line 120, in kill (/usr/lib/aarch64-linux-gnu/libc.so.6)
    (C) File "???", line 0, in __kernel_rt_sigreturn ([vdso: 492437])
    (C) File "/usr/lib/aarch64-linux-gnu/libffi.so.8.1.2", line 0, in ??? (/usr/lib/aarch64-linux-gnu/libffi.so.8.1.2)
    (C) File "/usr/lib/aarch64-linux-gnu/libffi.so.8.1.2", line 0, in ??? (/usr/lib/aarch64-linux-gnu/libffi.so.8.1.2)
    (C) File "./Modules/_ctypes/callbacks.c", line 302, in closure_fcn (/usr/local/python3.14t/lib/python3.14t/lib-dynload/_ctypes.cpython-314t-aarch64-linux-gnu.so)
    (C) File "./Modules/_ctypes/callbacks.c", line 210, in _CallPythonObject (/usr/local/python3.14t/lib/python3.14t/lib-dynload/_ctypes.cpython-314t-aarch64-linux-gnu.so)
```

**Additional context**
https://codebrowser.dev/llvm/libunwind/src/UnwindCursor.hpp.html#2810
