### PR TITLE
Require nanobind 2.x when building for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.4", "nanobind>=1.8"]
+requires = ["scikit-build-core>=0.4", "nanobind>=1.8", "nanobind<3; python_version < '3.10'"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Nanobind 3.x dropped support for Python 3.9, but its packaging metadata does not reflect that change. Work around this by declaring the restriction ourselves.

Note that as things stand today, anyone who wants to build any previously published sdist for Python 3.9 will need to supply the `--build-constraint` argument to `pip install` or the `--build-constraints` argument to `uv pip install` and provide a file containing a `nanobind < 3` constraint, essentially providing the metadata on each `pip install` call that isn't currently reflected in the `nanobind` package's published metadata.

Relates-to https://github.com/wjakob/nanobind/issues/1424